### PR TITLE
Add admin course tools and all class view

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -11,6 +11,7 @@ const authRoutes = require('./routes/authRoutes');
 const userRoutes = require('./routes/userRoutes');
 const courseRoutes = require('./routes/courseRoutes');
 const paymentRoutes = require('./routes/paymentRoutes');
+const bankPaymentRoutes = require('./routes/bankPaymentRoutes');
 
 const app = express();
 
@@ -34,6 +35,7 @@ app.use(
 app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/payment', paymentRoutes);
+app.use('/api/bank-payment', bankPaymentRoutes);
 app.use('/api', courseRoutes);
 
 

--- a/backend/routes/courseRoutes.js
+++ b/backend/routes/courseRoutes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const courseController = require('../controllers/courseController');
+const videoController = require('../controllers/uploadCourseVideo');
+const upload = require('../middleware/upload');
 const { authenticateToken } = require('../middleware/authMiddleware');
 
 // Course CRUD
@@ -13,5 +15,8 @@ router.delete('/courses/:id', authenticateToken, courseController.deleteCourse);
 
 // Add course content (manual embed or Bunny.net metadata)
 router.post('/courses/:id/content', authenticateToken, courseController.addCourseContent);
+
+// Upload video file directly to Bunny.net and attach to course
+router.post('/courses/:id/upload-video', authenticateToken, upload.single('video'), videoController.uploadCourseVideo);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import GradeList from './pages/Classes/GradeList';
 import SubjectList from './pages/Classes/SubjectList';
 import TeacherList from './pages/Classes/TeacherList';
 import ClassDetail from './pages/Classes/ClassDetail';
+import AllClasses from './pages/Classes/AllClasses';
 
 // Shop
 import Shop from './pages/Shop/Shop';
@@ -26,7 +27,10 @@ import PaymentHistory from './pages/Dashboard/PaymentHistory';
 import ELibrary from './pages/ELibrary/ELibrary';
 
 // Admin Pages
-import CourseUploader from './pages/Admin/CourseUploader'; // Bunny uploader
+import CourseUploader from './pages/Admin/CourseUploader';
+import CourseList from './pages/Admin/CourseList';
+import CreateCourse from './pages/Admin/CreateCourse';
+import RequireAdmin from './components/RequireAdmin';
 
 function App() {
   return (
@@ -40,7 +44,8 @@ function App() {
         <Route path="/" element={<Home />} />
 
         {/* Classes Flow */}
-        <Route path="/classes" element={<GradeList />} />
+        <Route path="/classes" element={<AllClasses />} />
+        <Route path="/classes/legacy" element={<GradeList />} />
         <Route path="/classes/:gradeId/subjects" element={<SubjectList />} />
         <Route path="/classes/:gradeId/:subjectId/teachers" element={<TeacherList />} />
         <Route path="/class/:classId" element={<ClassDetail />} />
@@ -61,8 +66,10 @@ function App() {
         {/* Library */}
         <Route path="/e-library" element={<ELibrary />} />
 
-        {/* Admin Upload Bunny.net Video */}
-        <Route path="/admin/courses/:courseId/upload" element={<CourseUploader />} />
+        {/* Admin */}
+        <Route path="/admin/courses" element={<RequireAdmin><CourseList /></RequireAdmin>} />
+        <Route path="/admin/courses/create" element={<RequireAdmin><CreateCourse /></RequireAdmin>} />
+        <Route path="/admin/courses/:courseId/upload" element={<RequireAdmin><CourseUploader /></RequireAdmin>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Admin/CourseList.jsx
+++ b/frontend/src/pages/Admin/CourseList.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../../api';
+
+function CourseList() {
+  const [courses, setCourses] = useState([]);
+
+  useEffect(() => {
+    api.get('/courses')
+      .then(res => setCourses(res.data.courses || []))
+      .catch(() => setCourses([]));
+  }, []);
+
+  return (
+    <div className="container mt-4">
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <h2>Courses</h2>
+        <Link className="btn btn-success" to="/admin/courses/create">New Course</Link>
+      </div>
+      <ul className="list-group">
+        {courses.map(c => (
+          <li key={c._id} className="list-group-item d-flex justify-content-between">
+            <span>{c.title}</span>
+            <Link className="btn btn-sm btn-outline-primary" to={`/admin/courses/${c._id}/upload`}>Upload Video</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default CourseList;

--- a/frontend/src/pages/Admin/CreateCourse.jsx
+++ b/frontend/src/pages/Admin/CreateCourse.jsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../../api';
+
+function CreateCourse() {
+  const [form, setForm] = useState({ title: '', description: '', price: '', durationInDays: 30 });
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await api.post('/courses', form);
+      setMessage('Course created!');
+      navigate(`/admin/courses/${res.data.course._id}/upload`);
+    } catch (err) {
+      setMessage('Creation failed.');
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h2>Create Course</h2>
+      {message && <div className="alert alert-info">{message}</div>}
+      <form onSubmit={handleSubmit}>
+        <input
+          className="form-control mb-2"
+          name="title"
+          placeholder="Title"
+          value={form.title}
+          onChange={handleChange}
+          required
+        />
+        <textarea
+          className="form-control mb-2"
+          name="description"
+          placeholder="Description"
+          value={form.description}
+          onChange={handleChange}
+        />
+        <input
+          className="form-control mb-2"
+          name="price"
+          type="number"
+          placeholder="Price"
+          value={form.price}
+          onChange={handleChange}
+          required
+        />
+        <input
+          className="form-control mb-2"
+          name="durationInDays"
+          type="number"
+          placeholder="Duration in days"
+          value={form.durationInDays}
+          onChange={handleChange}
+        />
+        <button className="btn btn-primary">Create</button>
+      </form>
+    </div>
+  );
+}
+
+export default CreateCourse;

--- a/frontend/src/pages/Classes/AllClasses.jsx
+++ b/frontend/src/pages/Classes/AllClasses.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../../api';
+
+function AllClasses() {
+  const [classes, setClasses] = useState([]);
+
+  useEffect(() => {
+    api.get('/courses')
+      .then(res => setClasses(res.data.courses || []))
+      .catch(() => setClasses([]));
+  }, []);
+
+  return (
+    <div className="container py-4">
+      <h4>All Classes</h4>
+      <ul className="list-group">
+        {classes.map(cls => (
+          <Link key={cls._id} to={`/class/${cls._id}`} className="list-group-item">
+            {cls.title} - Rs. {cls.price}
+          </Link>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default AllClasses;

--- a/frontend/src/pages/Classes/ClassDetail.jsx
+++ b/frontend/src/pages/Classes/ClassDetail.jsx
@@ -7,7 +7,7 @@ const ClassDetail = () => {
   const navigate = useNavigate();
   const [classData, setClassData] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [slip, setSlip] = useState(null);
+  const [slipUrl, setSlipUrl] = useState('');
   const [message, setMessage] = useState('');
 
   const token = localStorage.getItem('token');
@@ -28,15 +28,15 @@ const ClassDetail = () => {
   const handleBankSubmit = async (e) => {
     e.preventDefault();
     if (!token) return navigate('/login');
-    if (!slip) return setMessage('Please choose a slip file.');
-
-    const formData = new FormData();
-    formData.append('courseId', classId);
-    formData.append('slip', slip);
+    if (!slipUrl) return setMessage('Please provide the slip URL.');
 
     try {
-      await api.post('/payment/bank-upload', formData);
-      setMessage('Slip uploaded! Awaiting admin approval.');
+      await api.post('/bank-payment/submit', {
+        courseId: classId,
+        zipUrl: slipUrl
+      });
+      setMessage('Slip submitted! Awaiting admin approval.');
+      setSlipUrl('');
     } catch (err) {
       setMessage('Upload failed.');
     }
@@ -89,9 +89,15 @@ const ClassDetail = () => {
 
       {token && (
         <>
-          <h5>📤 Upload Bank Slip</h5>
+          <h5>📤 Submit Bank Slip</h5>
           <form onSubmit={handleBankSubmit} className="mb-4">
-            <input type="file" className="form-control mb-2" onChange={(e) => setSlip(e.target.files[0])} />
+            <input
+              type="text"
+              className="form-control mb-2"
+              placeholder="Slip URL"
+              value={slipUrl}
+              onChange={(e) => setSlipUrl(e.target.value)}
+            />
             <button className="btn btn-outline-secondary">Submit Slip</button>
           </form>
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -38,6 +38,9 @@ const Home = () => {
         <Tile title="Shop" icon="🛒" link="/shop" />
         <Tile title="Student Dashboard" icon="📊" link="/dashboard" />
         <Tile title="E-Library" icon="📚" link="/e-library" />
+        {user?.userRole === 'admin' && (
+          <Tile title="Admin" icon="⚙️" link="/admin/courses" />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- enable bank payment routes and bunny video upload endpoint
- allow admins to manage courses on frontend
- list all classes for students
- submit bank slip URL instead of file
- show admin link on homepage

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in `frontend` *(fails to resolve @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68551a5cc6b88322be0519e61a11ff16