### PR TITLE
Add OTP utility test

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -25,6 +25,7 @@
     "twilio": "^5.6.1"
   },
   "devDependencies": {
-    "concurrently": "^9.1.2"
+    "concurrently": "^9.1.2",
+    "jest": "^29.7.0"
   }
 }

--- a/backend/tests/testOtpUtils.test.js
+++ b/backend/tests/testOtpUtils.test.js
@@ -1,0 +1,7 @@
+const { generateOtp } = require('../utils/otpUtils');
+
+test('generateOtp returns a 6-digit numeric string', () => {
+  const otp = generateOtp();
+  expect(typeof otp).toBe('string');
+  expect(otp).toMatch(/^\d{6}$/);
+});


### PR DESCRIPTION
## Summary
- add Jest test for `generateOtp`
- configure Jest test script in `backend/package.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551e06a3348322ab021e60e4d1b84e