### PR TITLE
Fix my-courses API response

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -47,7 +47,9 @@ exports.getMyCourses = async (req, res) => {
   const userId = req.user.userId;
   const accessList = await UserCourseAccess.find({ userId, expiresAt: { $gt: new Date() } }).populate('courseId');
   const courses = accessList.map(access => access.courseId);
-  res.json({ courses });
+  // For the dashboard, the frontend expects the enrolled classes under the
+  // `classes` key. Keep this naming to avoid breaking the existing UI.
+  res.json({ classes: courses });
 };
 
 // Update user role (Admin only)


### PR DESCRIPTION
## Summary
- return `classes` key from `/users/my-courses` so dashboard works

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685523f1f63c8322bf4e81cb807215b4