### PR TITLE
Ensure PayHere payments grant course access

### DIFF
--- a/backend/controllers/paymentController.js
+++ b/backend/controllers/paymentController.js
@@ -232,6 +232,23 @@ exports.verifyPayment = async (req, res) => {
       return res.status(403).json({ message: 'Unauthorized or payment not found' });
     }
 
+    if (payment.status === 'completed') {
+      const existing = await UserCourseAccess.findOne({
+        userId,
+        courseId: payment.courseId._id,
+        expiresAt: { $gt: new Date() }
+      });
+
+      if (!existing) {
+        await UserCourseAccess.create({
+          userId,
+          courseId: payment.courseId._id,
+          purchasedAt: payment.completedAt || new Date(),
+          expiresAt: getNext8th()
+        });
+      }
+    }
+
     res.json({ success: true, payment });
   } catch (error) {
     console.error('Verify error:', error.message);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ import Marks from './pages/Dashboard/Marks';
 import Attendance from './pages/Dashboard/Attendance';
 import PaymentHistory from './pages/Dashboard/PaymentHistory';
 import ELibrary from './pages/ELibrary/ELibrary';
+import PaymentSuccess from './pages/PaymentSuccess';
 
 // Admin Pages
 import CourseUploader from './pages/Admin/CourseUploader';
@@ -53,6 +54,9 @@ function App() {
         {/* Shop */}
         <Route path="/shop" element={<Shop />} />
         <Route path="/shop/cart" element={<Cart />} />
+
+        {/* Payment return */}
+        <Route path="/payment-success" element={<PaymentSuccess />} />
 
         {/* Dashboard */}
         <Route path="/dashboard" element={<MyClasses />} />

--- a/frontend/src/pages/PaymentSuccess.jsx
+++ b/frontend/src/pages/PaymentSuccess.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import api from '../api';
+
+const PaymentSuccess = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [message, setMessage] = useState('Verifying payment...');
+
+  useEffect(() => {
+    const orderId = searchParams.get('order');
+    if (!orderId) {
+      setMessage('No order id provided.');
+      return;
+    }
+
+    const verify = async () => {
+      try {
+        await api.post('/payment/verify-payment', { orderId });
+        setMessage('Payment verified! Redirecting to dashboard...');
+        setTimeout(() => navigate('/dashboard'), 1500);
+      } catch (err) {
+        setMessage('Payment verification failed.');
+      }
+    };
+
+    verify();
+  }, [searchParams, navigate]);
+
+  return (
+    <div className="container py-4">
+      <p>{message}</p>
+    </div>
+  );
+};
+
+export default PaymentSuccess;


### PR DESCRIPTION
## Summary
- add missing logic to grant access when verifying payments
- create a PaymentSuccess page to verify the payment from the frontend
- register PaymentSuccess route in `App.jsx`

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855263131c48322a79c873bb85e79a0