### PR TITLE
Add admin payment management

### DIFF
--- a/backend/routes/paymentRoutes.js
+++ b/backend/routes/paymentRoutes.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const paymentController = require('../controllers/paymentController');
-const { authenticateToken } = require('../middleware/authMiddleware');
+const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
 
 router.post('/initiate-payment', authenticateToken, paymentController.initiatePayment);
 router.get('/return', paymentController.handlePaymentReturn);
@@ -9,5 +9,6 @@ router.get('/cancel', paymentController.handlePaymentCancel);
 router.post('/notify', paymentController.handlePaymentNotify);
 router.post('/verify-payment', authenticateToken, paymentController.verifyPayment);
 router.get('/history', authenticateToken, paymentController.getPaymentHistory);
+router.get('/all', authenticateToken, requireAdmin, paymentController.getAllPayments);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,6 +31,7 @@ import PaymentSuccess from './pages/PaymentSuccess';
 import CourseUploader from './pages/Admin/CourseUploader';
 import CourseList from './pages/Admin/CourseList';
 import CreateCourse from './pages/Admin/CreateCourse';
+import PaymentList from './pages/Admin/PaymentList';
 import RequireAdmin from './components/RequireAdmin';
 
 function App() {
@@ -74,6 +75,7 @@ function App() {
         <Route path="/admin/courses" element={<RequireAdmin><CourseList /></RequireAdmin>} />
         <Route path="/admin/courses/create" element={<RequireAdmin><CreateCourse /></RequireAdmin>} />
         <Route path="/admin/courses/:courseId/upload" element={<RequireAdmin><CourseUploader /></RequireAdmin>} />
+        <Route path="/admin/payments" element={<RequireAdmin><PaymentList /></RequireAdmin>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Admin/PaymentList.jsx
+++ b/frontend/src/pages/Admin/PaymentList.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+
+function PaymentList() {
+  const [payments, setPayments] = useState([]);
+
+  useEffect(() => {
+    api.get('/payment/all')
+      .then(res => setPayments(res.data.payments || []))
+      .catch(() => setPayments([]));
+  }, []);
+
+  return (
+    <div className="container mt-4">
+      <h2>Payments</h2>
+      <ul className="list-group">
+        {payments.map(p => (
+          <li key={p._id} className="list-group-item d-flex justify-content-between">
+            <span>
+              {p.userId?.firstName} {p.userId?.lastName} - {p.courseId?.title}
+            </span>
+            <span>
+              {p.status}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default PaymentList;

--- a/frontend/src/pages/Dashboard/PaymentHistory.jsx
+++ b/frontend/src/pages/Dashboard/PaymentHistory.jsx
@@ -1,16 +1,22 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+
 const PaymentHistory = () => {
-  const payments = [
-    { orderId: 'ORD123', amount: 2500, date: '2025-06-01' },
-    { orderId: 'ORD124', amount: 2500, date: '2025-07-01' }
-  ];
+  const [payments, setPayments] = useState([]);
+
+  useEffect(() => {
+    api.get('/payment/history')
+      .then(res => setPayments(res.data.payments || []))
+      .catch(() => setPayments([]));
+  }, []);
 
   return (
     <div className="container py-4">
       <h4>Payment History</h4>
       <ul className="list-group">
-        {payments.map((p, i) => (
-          <li key={i} className="list-group-item">
-            Order: {p.orderId} – Rs. {p.amount} – {p.date}
+        {payments.map((p) => (
+          <li key={p._id} className="list-group-item">
+            Order: {p.orderId} – Rs. {p.amount} – {new Date(p.createdAt).toLocaleDateString()} – {p.status}
           </li>
         ))}
       </ul>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -39,7 +39,10 @@ const Home = () => {
         <Tile title="Student Dashboard" icon="📊" link="/dashboard" />
         <Tile title="E-Library" icon="📚" link="/e-library" />
         {user?.userRole === 'admin' && (
-          <Tile title="Admin" icon="⚙️" link="/admin/courses" />
+          <>
+            <Tile title="Admin" icon="⚙️" link="/admin/courses" />
+            <Tile title="Payments" icon="💳" link="/admin/payments" />
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow admins to verify any payment
- expose `/api/payment/all` for admins
- list payments in admin dashboard
- fetch real payment history for students
- link to admin payment list from home page

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552969e098832296ef2aca6eae35ff