### PR TITLE
Enable bank payment approvals

### DIFF
--- a/backend/controllers/bankPaymentController.js
+++ b/backend/controllers/bankPaymentController.js
@@ -25,3 +25,21 @@ exports.approveBankPayment = async (req, res) => {
   res.json({ message: 'Payment approved and access granted' });
 };
 
+// Fetch bank payment requests (admin)
+exports.getBankPaymentRequests = async (req, res) => {
+  const status = req.query.status || 'pending';
+  const requests = await BankPaymentRequest.find({ status })
+    .populate('userId', 'firstName lastName')
+    .populate('courseId', 'title');
+  res.json({ requests });
+};
+
+// Fetch current user's bank payment requests
+exports.getMyBankPayments = async (req, res) => {
+  const userId = req.user.userId;
+  const requests = await BankPaymentRequest.find({ userId })
+    .populate('courseId', 'title')
+    .sort({ createdAt: -1 });
+  res.json({ requests });
+};
+

--- a/backend/routes/bankPaymentRoutes.js
+++ b/backend/routes/bankPaymentRoutes.js
@@ -5,5 +5,7 @@ const { authenticateToken, requireAdmin } = require('../middleware/authMiddlewar
 
 router.post('/submit', authenticateToken, controller.submitBankPayment);
 router.put('/approve/:requestId', authenticateToken, requireAdmin, controller.approveBankPayment);
+router.get('/requests', authenticateToken, requireAdmin, controller.getBankPaymentRequests);
+router.get('/my', authenticateToken, controller.getMyBankPayments);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,6 +32,7 @@ import CourseUploader from './pages/Admin/CourseUploader';
 import CourseList from './pages/Admin/CourseList';
 import CreateCourse from './pages/Admin/CreateCourse';
 import PaymentList from './pages/Admin/PaymentList';
+import BankPaymentRequests from './pages/Admin/BankPaymentRequests';
 import RequireAdmin from './components/RequireAdmin';
 
 function App() {
@@ -76,6 +77,7 @@ function App() {
         <Route path="/admin/courses/create" element={<RequireAdmin><CreateCourse /></RequireAdmin>} />
         <Route path="/admin/courses/:courseId/upload" element={<RequireAdmin><CourseUploader /></RequireAdmin>} />
         <Route path="/admin/payments" element={<RequireAdmin><PaymentList /></RequireAdmin>} />
+        <Route path="/admin/bank-payments" element={<RequireAdmin><BankPaymentRequests /></RequireAdmin>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Admin/BankPaymentRequests.jsx
+++ b/frontend/src/pages/Admin/BankPaymentRequests.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+
+function BankPaymentRequests() {
+  const [requests, setRequests] = useState([]);
+
+  const loadRequests = () => {
+    api.get('/bank-payment/requests')
+      .then(res => setRequests(res.data.requests || []))
+      .catch(() => setRequests([]));
+  };
+
+  useEffect(() => {
+    loadRequests();
+  }, []);
+
+  const approve = async (id) => {
+    try {
+      await api.put(`/bank-payment/approve/${id}`);
+      loadRequests();
+    } catch (err) {
+      console.error('Approve failed', err);
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h2>Bank Payment Requests</h2>
+      <ul className="list-group">
+        {requests.map(r => (
+          <li key={r._id} className="list-group-item d-flex justify-content-between align-items-center">
+            <span>
+              {r.userId?.firstName} {r.userId?.lastName} - {r.courseId?.title}
+            </span>
+            <button
+              className="btn btn-sm btn-success"
+              onClick={() => approve(r._id)}
+            >
+              Approve
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default BankPaymentRequests;

--- a/frontend/src/pages/Dashboard/PaymentHistory.jsx
+++ b/frontend/src/pages/Dashboard/PaymentHistory.jsx
@@ -3,11 +3,15 @@ import api from '../../api';
 
 const PaymentHistory = () => {
   const [payments, setPayments] = useState([]);
+  const [bankPayments, setBankPayments] = useState([]);
 
   useEffect(() => {
     api.get('/payment/history')
       .then(res => setPayments(res.data.payments || []))
       .catch(() => setPayments([]));
+    api.get('/bank-payment/my')
+      .then(res => setBankPayments(res.data.requests || []))
+      .catch(() => setBankPayments([]));
   }, []);
 
   return (
@@ -17,6 +21,11 @@ const PaymentHistory = () => {
         {payments.map((p) => (
           <li key={p._id} className="list-group-item">
             Order: {p.orderId} – Rs. {p.amount} – {new Date(p.createdAt).toLocaleDateString()} – {p.status}
+          </li>
+        ))}
+        {bankPayments.map((b) => (
+          <li key={b._id} className="list-group-item">
+            Bank slip for {b.courseId?.title} – {b.status}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- expose new APIs to fetch bank payment requests
- allow users to see their bank payment submissions
- add admin UI for approving bank payments
- show bank payment records in dashboard payment history

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552b02f8e4832289d7e390fc5b5c03