### PR TITLE
Fix upload directory

### DIFF
--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -1,8 +1,17 @@
 const multer = require('multer');
 const path = require('path');
+const fs = require('fs');
+
+// Directory where temporary uploads will be stored before
+// being sent to Bunny.net. Multer does not create this
+// automatically, so ensure it exists.
+const uploadDir = path.join(__dirname, '..', 'uploads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
 
 const storage = multer.diskStorage({
-  destination: (req, file, cb) => cb(null, 'uploads/'),
+  destination: (req, file, cb) => cb(null, uploadDir),
   filename: (req, file, cb) => {
     const uniqueName = `${Date.now()}-${file.originalname}`;
     cb(null, uniqueName);


### PR DESCRIPTION
## Summary
- make sure temporary uploads directory exists before saving videos

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855314a943883229a84623e4319228b