### PR TITLE
Add admin video listing

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -12,6 +12,7 @@ const userRoutes = require('./routes/userRoutes');
 const courseRoutes = require('./routes/courseRoutes');
 const paymentRoutes = require('./routes/paymentRoutes');
 const bankPaymentRoutes = require('./routes/bankPaymentRoutes');
+const bunnyRoutes = require('./routes/bunnyRoutes');
 
 const app = express();
 
@@ -37,6 +38,7 @@ app.use('/api/users', userRoutes);
 app.use('/api/payment', paymentRoutes);
 app.use('/api/bank-payment', bankPaymentRoutes);
 app.use('/api', courseRoutes);
+app.use('/api', bunnyRoutes);
 
 
 

--- a/backend/controllers/bunnyController.js
+++ b/backend/controllers/bunnyController.js
@@ -1,0 +1,18 @@
+const axios = require('axios');
+
+const BUNNY_API_KEY = process.env.BUNNY_API_KEY;
+const BUNNY_LIBRARY_ID = process.env.BUNNY_LIBRARY_ID;
+
+exports.listVideos = async (req, res) => {
+  try {
+    const { page = 1, perPage = 100 } = req.query;
+    const bunnyRes = await axios.get(
+      `https://video.bunnycdn.com/library/${BUNNY_LIBRARY_ID}/videos?page=${page}&itemsPerPage=${perPage}`,
+      { headers: { AccessKey: BUNNY_API_KEY } }
+    );
+    res.json({ videos: bunnyRes.data.items || [] });
+  } catch (error) {
+    console.error('Bunny list error:', error.message);
+    res.status(500).json({ message: 'Failed to fetch videos', error: error.message });
+  }
+};

--- a/backend/routes/bunnyRoutes.js
+++ b/backend/routes/bunnyRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const bunnyController = require('../controllers/bunnyController');
+const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
+
+router.get('/bunny/videos', authenticateToken, requireAdmin, bunnyController.listVideos);
+
+module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,7 @@ import CourseList from './pages/Admin/CourseList';
 import CreateCourse from './pages/Admin/CreateCourse';
 import PaymentList from './pages/Admin/PaymentList';
 import BankPaymentRequests from './pages/Admin/BankPaymentRequests';
+import BunnyVideoList from './pages/Admin/BunnyVideoList';
 import RequireAdmin from './components/RequireAdmin';
 
 function App() {
@@ -78,6 +79,7 @@ function App() {
         <Route path="/admin/courses/:courseId/upload" element={<RequireAdmin><CourseUploader /></RequireAdmin>} />
         <Route path="/admin/payments" element={<RequireAdmin><PaymentList /></RequireAdmin>} />
         <Route path="/admin/bank-payments" element={<RequireAdmin><BankPaymentRequests /></RequireAdmin>} />
+        <Route path="/admin/videos" element={<RequireAdmin><BunnyVideoList /></RequireAdmin>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Admin/BunnyVideoList.jsx
+++ b/frontend/src/pages/Admin/BunnyVideoList.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+
+function BunnyVideoList() {
+  const [videos, setVideos] = useState([]);
+
+  useEffect(() => {
+    api.get('/bunny/videos')
+      .then(res => setVideos(res.data.videos || []))
+      .catch(() => setVideos([]));
+  }, []);
+
+  return (
+    <div className="container mt-4">
+      <h2>Bunny Videos</h2>
+      <ul className="list-group">
+        {videos.map(v => (
+          <li key={v.guid} className="list-group-item">
+            {v.title || v.guid}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default BunnyVideoList;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -42,6 +42,7 @@ const Home = () => {
           <>
             <Tile title="Admin" icon="⚙️" link="/admin/courses" />
             <Tile title="Payments" icon="💳" link="/admin/payments" />
+            <Tile title="Videos" icon="🎞️" link="/admin/videos" />
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add Bunny video controller and routes
- expose bunny routes in app
- create admin page to list videos
- link to videos page in home

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm run lint --prefix frontend` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685544bdae7083229c3bd9d92e71c586