### PR TITLE
Fix env loading path for backend

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,5 +1,6 @@
 // app.js
-require('dotenv').config();
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');


### PR DESCRIPTION
## Summary
- ensure backend always loads `.env` by specifying the file path

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685546bbf22483228df576b1ceb52d7e