### PR TITLE
Fix large upload issue

### DIFF
--- a/backend/controllers/uploadCourseVideo.js
+++ b/backend/controllers/uploadCourseVideo.js
@@ -34,7 +34,10 @@ exports.uploadCourseVideo = async (req, res) => {
         headers: {
           AccessKey: BUNNY_API_KEY,
           'Content-Type': 'application/octet-stream'
-        }
+        },
+        // Large video files easily exceed axios' default 10MB body limit
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity
       }
     );
 


### PR DESCRIPTION
## Summary
- allow bigger video uploads to BunnyCDN by raising axios limits

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554bdab16c8322a0d7277c91a1dd13