### PR TITLE
Fix video upload error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ This repository contains a Node.js backend and a React frontend.
 
 Copy `backend/.env.example` to `backend/.env` and provide values for each variable. The backend uses Bunny.net for video uploads. You must set `BUNNY_API_KEY` and `BUNNY_LIBRARY_ID` with your credentials in the `.env` file.
 
+### Video upload endpoint
+
+Videos are uploaded via `POST /api/courses/:id/upload-video`. This route requires
+an authenticated request using a Bearer token and valid Bunny.net credentials.
+Attempting to open the URL directly in a browser (a `GET` request) will result
+in `Cannot GET /api/.../upload-video`.
+

--- a/backend/controllers/uploadCourseVideo.js
+++ b/backend/controllers/uploadCourseVideo.js
@@ -62,7 +62,16 @@ exports.uploadCourseVideo = async (req, res) => {
 
     res.status(200).json({ message: 'Video uploaded and added to course', videoUrl, course });
   } catch (error) {
-    console.error('Upload error:', error.message);
-    res.status(500).json({ message: 'Video upload failed', error: error.message });
+    // If Bunny.net returns an error (e.g. invalid API key) the status code is
+    // available on error.response. Propagate that status code to the client so
+    // the frontend can show a more meaningful message.
+    const status = error.response?.status || 500;
+    const msg =
+      error.response?.data?.message ||
+      error.message ||
+      'Video upload failed';
+
+    console.error('Upload error:', msg);
+    res.status(status).json({ message: msg });
   }
 };


### PR DESCRIPTION
## Summary
- document the POST /api/courses/:id/upload-video endpoint and auth requirement
- improve error propagation when Bunny.net returns an error

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685550b989e08322b17df7b2ed884273