### PR TITLE
Fix Bunny API header whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,6 @@ A 401 response usually means the Bunny API rejected the credentials. Double-chec
 3. Make sure the API key is the **Stream API Key** for that library (the Storage key will cause a 401 error).
 4. If uploading to a storage zone, verify `BUNNY_STORAGE_ZONE_NAME`, `BUNNY_STORAGE_ACCESS_KEY`, and `BUNNY_STORAGE_REGION`.
 5. Restart the backend server after updating `.env` so new values are loaded.
+6. Ensure no extra whitespace or newline characters are present in your `.env` values.
 
 

--- a/backend/controllers/bunnyController.js
+++ b/backend/controllers/bunnyController.js
@@ -1,7 +1,8 @@
 const axios = require('axios');
 
-const BUNNY_API_KEY = process.env.BUNNY_API_KEY;
-const BUNNY_LIBRARY_ID = process.env.BUNNY_LIBRARY_ID;
+// Trim to prevent stray whitespace from breaking authentication
+const BUNNY_API_KEY = process.env.BUNNY_API_KEY?.trim();
+const BUNNY_LIBRARY_ID = process.env.BUNNY_LIBRARY_ID?.trim();
 
 exports.listVideos = async (req, res) => {
   try {

--- a/backend/controllers/uploadCourseVideo.js
+++ b/backend/controllers/uploadCourseVideo.js
@@ -3,8 +3,9 @@ const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
 
-const BUNNY_API_KEY = process.env.BUNNY_API_KEY;
-const BUNNY_LIBRARY_ID = process.env.BUNNY_LIBRARY_ID;
+// Trim to avoid accidental whitespace causing auth failures
+const BUNNY_API_KEY = process.env.BUNNY_API_KEY?.trim();
+const BUNNY_LIBRARY_ID = process.env.BUNNY_LIBRARY_ID?.trim();
 
 // Upload video file to Bunny.net
 exports.uploadCourseVideo = async (req, res) => {


### PR DESCRIPTION
## Summary
- avoid whitespace issues in Bunny credentials
- document common env typo for 401 errors

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685589034dd08322b8466ebde6401c92