### PR TITLE
Fix logout on Bunny upload failure

### DIFF
--- a/frontend/src/components/BunnyFileUploader.jsx
+++ b/frontend/src/components/BunnyFileUploader.jsx
@@ -108,9 +108,18 @@ const BunnyFileUploader = ({ courseId }) => {
         
         switch (err.response.status) {
           case 401:
-            errorMessage = '❌ Authentication failed. Please log in again.';
-            localStorage.removeItem('token');
-            localStorage.removeItem('user');
+            // Distinguish between backend auth failure and Bunny API failure
+            if (
+              err.response.data?.message &&
+              err.response.data.message.toLowerCase().includes('bunny')
+            ) {
+              // Bunny returned 401 (likely invalid API key). Do not logout.
+              errorMessage = `❌ ${err.response.data.message}`;
+            } else {
+              errorMessage = '❌ Authentication failed. Please log in again.';
+              localStorage.removeItem('token');
+              localStorage.removeItem('user');
+            }
             break;
           case 403:
             errorMessage = '❌ You do not have permission to upload videos.';


### PR DESCRIPTION
## Summary
- update BunnyFileUploader error handling to avoid logging out when Bunny API fails

## Testing
- `npm --prefix backend test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558c11e49883229760d8bc7b065341