### PR TITLE
Switch admin video upload to URL-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,15 @@ If you want to upload files directly to a Bunny storage zone, also provide `BUNN
 
 ### Video upload endpoint
 
-Videos are uploaded via `POST /api/courses/:id/upload-video`. This route requires
-an authenticated request using a Bearer token and valid Bunny.net credentials.
-Attempting to open the URL directly in a browser (a `GET` request) will result
-in `Cannot GET /api/.../upload-video`.
+Videos can be attached to a course by sending a Bunny.net video URL to
+`POST /api/courses/:id/content`. The body accepts `title`, `videoId`,
+`videoUrl`, `isPublic` and optional subtitles. The former file upload route
+`POST /api/courses/:id/upload-video` still exists but the admin dashboard now
+uses the URL method.
+
+Both routes require an authenticated request using a Bearer token. Attempting to
+open either endpoint in a browser with a `GET` request will result in
+`Cannot GET /api/...`.
 
 ### Uploading files to a storage zone
 

--- a/frontend/src/components/UploadCourseContent.jsx
+++ b/frontend/src/components/UploadCourseContent.jsx
@@ -51,7 +51,7 @@ function UploadCourseContent({ courseId }) {
 
   return (
     <div className="mt-5 border p-4 rounded">
-      <h4>📤 Upload Course Video Metadata</h4>
+      <h4>📤 Add Bunny.net Video URL</h4>
       {message && <div className="alert alert-info">{message}</div>}
       <form onSubmit={handleSubmit}>
         <input type="text" name="title" value={form.title} onChange={handleChange}
@@ -82,7 +82,7 @@ function UploadCourseContent({ courseId }) {
         ))}
         <button type="button" className="btn btn-secondary mb-3" onClick={addSubtitleField}>+ Add Subtitle</button>
 
-        <button type="submit" className="btn btn-primary w-100">Upload Metadata</button>
+        <button type="submit" className="btn btn-primary w-100">Save Video URL</button>
       </form>
     </div>
   );

--- a/frontend/src/pages/Admin/CourseList.jsx
+++ b/frontend/src/pages/Admin/CourseList.jsx
@@ -21,7 +21,7 @@ function CourseList() {
         {courses.map(c => (
           <li key={c._id} className="list-group-item d-flex justify-content-between">
             <span>{c.title}</span>
-            <Link className="btn btn-sm btn-outline-primary" to={`/admin/courses/${c._id}/upload`}>Upload Video</Link>
+            <Link className="btn btn-sm btn-outline-primary" to={`/admin/courses/${c._id}/upload`}>Add Video URL</Link>
           </li>
         ))}
       </ul>

--- a/frontend/src/pages/Admin/CourseUploader.jsx
+++ b/frontend/src/pages/Admin/CourseUploader.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import BunnyFileUploader from '../../components/BunnyFileUploader';
+import UploadCourseContent from '../../components/UploadCourseContent';
 import AuthDebug from '../../components/AuthDebug';
 
 function CourseUploader() {
@@ -53,7 +53,7 @@ function CourseUploader() {
     <div className="container mt-4">
       <div className="d-flex justify-content-between align-items-center mb-3">
         <div>
-          <h2>🎬 Admin - Upload Video to Course</h2>
+          <h2>🎬 Admin - Add Video URL to Course</h2>
           <p className="text-muted">Course ID: {courseId}</p>
           <p className="text-muted">Logged in as: {userInfo.firstName} {userInfo.lastName} ({userInfo.userRole})</p>
         </div>
@@ -66,8 +66,8 @@ function CourseUploader() {
       </div>
 
       {showDebug && <AuthDebug />}
-      
-      <BunnyFileUploader courseId={courseId} />
+
+      <UploadCourseContent courseId={courseId} />
       
       <div className="mt-4">
         <button 


### PR DESCRIPTION
## Summary
- adjust README instructions for new video URL endpoint
- tweak UploadCourseContent texts
- update admin pages to use URL form instead of file upload

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm run lint --prefix frontend` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68579bad8b34832291d514cc2936a36e