### PR TITLE
Add teacher management tile

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -40,9 +40,10 @@ const Home = () => {
         <Tile title="E-Library" icon="📚" link="/e-library" />
         {user?.userRole === 'admin' && (
           <>
-            <Tile title="Admin" icon="⚙️" link="/admin/courses" />
-            <Tile title="Payments" icon="💳" link="/admin/payments" />
-            <Tile title="Videos" icon="🎞️" link="/admin/videos" />
+          <Tile title="Admin" icon="⚙️" link="/admin/courses" />
+          <Tile title="Payments" icon="💳" link="/admin/payments" />
+          <Tile title="Videos" icon="🎞️" link="/admin/videos" />
+          <Tile title="Teachers" icon="🧑‍🏫" link="/admin/teachers" />
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- show a Teachers card in the admin section of the home dashboard

## Testing
- `npm --prefix backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a579288c8322a6ba31aecaac3891