### PR TITLE
Use teacher table in course creation

### DIFF
--- a/frontend/src/pages/Admin/CreateCourse.jsx
+++ b/frontend/src/pages/Admin/CreateCourse.jsx
@@ -16,8 +16,8 @@ function CreateCourse() {
 
   useEffect(() => {
     api
-      .get('/users/role/teacher')
-      .then((res) => setTeachers(res.data))
+      .get('/teachers')
+      .then((res) => setTeachers(res.data.teachers || []))
       .catch(() => setTeachers([]));
   }, []);
 


### PR DESCRIPTION
## Summary
- update admin course creation form to load teachers from the teachers table

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a6b70c7c8322b5d353eb045b82ef