### PR TITLE
Implement grade and subject based course flow

### DIFF
--- a/backend/controllers/teacherController.js
+++ b/backend/controllers/teacherController.js
@@ -15,6 +15,7 @@ exports.getTeachers = async (req, res) => {
   try {
     const query = {};
     if (req.query.grade) query.grade = parseInt(req.query.grade, 10);
+    if (req.query.subject) query.subject = req.query.subject;
 
     const teachers = await Teacher.find(query).sort({ createdAt: -1 });
     res.json({ teachers });
@@ -54,5 +55,20 @@ exports.deleteTeacher = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'Failed to delete teacher' });
+  }
+};
+
+// Get distinct subjects for a given grade
+exports.getAvailableSubjects = async (req, res) => {
+  try {
+    const grade = parseInt(req.query.grade, 10);
+    if (!grade) {
+      return res.status(400).json({ message: 'Grade is required' });
+    }
+    const subjects = await Teacher.find({ grade }).distinct('subject');
+    res.json({ subjects });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to fetch subjects' });
   }
 };

--- a/backend/models/Teacher.js
+++ b/backend/models/Teacher.js
@@ -4,6 +4,7 @@ const teacherSchema = new mongoose.Schema({
   firstName: { type: String, required: true },
   lastName: { type: String, required: true },
   grade: { type: Number },
+  subject: { type: String, required: true },
   email: { type: String },
   phoneNumber: { type: String },
   description: { type: String }

--- a/backend/routes/teacherRoutes.js
+++ b/backend/routes/teacherRoutes.js
@@ -5,6 +5,7 @@ const { authenticateToken, requireAdmin } = require('../middleware/authMiddlewar
 
 router.post('/', authenticateToken, requireAdmin, controller.createTeacher);
 router.get('/', controller.getTeachers);
+router.get('/available-subjects', controller.getAvailableSubjects);
 router.get('/:id', controller.getTeacherById);
 router.put('/:id', authenticateToken, requireAdmin, controller.updateTeacher);
 router.delete('/:id', authenticateToken, requireAdmin, controller.deleteTeacher);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Register from './pages/Auth/Register';
 
 // Class Navigation
 import GradeList from './pages/Classes/GradeList';
+import SubjectList from './pages/Classes/SubjectList';
 import TeacherList from './pages/Classes/TeacherList';
 import TeacherCourses from './pages/Classes/TeacherCourses';
 import ClassDetail from './pages/Classes/ClassDetail';
@@ -53,6 +54,9 @@ function App() {
         {/* Classes Flow */}
         <Route path="/classes" element={<GradeList />} />
         <Route path="/classes/all" element={<AllClasses />} />
+        <Route path="/classes/:gradeId/subjects" element={<SubjectList />} />
+        <Route path="/classes/:gradeId/subjects/:subjectName/teachers" element={<TeacherList />} />
+        <Route path="/classes/:gradeId/subjects/:subjectName/teachers/:teacherId" element={<TeacherCourses />} />
         <Route path="/classes/:gradeId/teachers" element={<TeacherList />} />
         <Route path="/classes/:gradeId/teachers/:teacherId" element={<TeacherCourses />} />
         <Route path="/class/:classId" element={<ClassDetail />} />

--- a/frontend/src/pages/Admin/CreateCourse.jsx
+++ b/frontend/src/pages/Admin/CreateCourse.jsx
@@ -9,25 +9,46 @@ function CreateCourse() {
     price: '',
     durationInDays: 30,
     grade: '',
+    subject: '',
     teacherName: ''
   });
   const [teachers, setTeachers] = useState([]);
+  const [subjects, setSubjects] = useState([]);
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
 
   useEffect(() => {
     if (!form.grade) {
       setTeachers([]);
+      setSubjects([]);
       return;
     }
     api
-      .get(`/teachers?grade=${form.grade}`)
-      .then((res) => setTeachers(res.data.teachers || []))
-      .catch(() => setTeachers([]));
+      .get(`/teachers/available-subjects?grade=${form.grade}`)
+      .then((res) => setSubjects(res.data.subjects || []))
+      .catch(() => setSubjects([]));
   }, [form.grade]);
 
+  useEffect(() => {
+    if (!form.grade || !form.subject) {
+      setTeachers([]);
+      return;
+    }
+    api
+      .get(`/teachers?grade=${form.grade}&subject=${encodeURIComponent(form.subject)}`)
+      .then((res) => setTeachers(res.data.teachers || []))
+      .catch(() => setTeachers([]));
+  }, [form.grade, form.subject]);
+
   const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const { name, value } = e.target;
+    if (name === 'grade') {
+      setForm({ ...form, grade: value, subject: '', teacherName: '' });
+    } else if (name === 'subject') {
+      setForm({ ...form, subject: value, teacherName: '' });
+    } else {
+      setForm({ ...form, [name]: value });
+    }
   };
 
   const handleSubmit = async (e) => {
@@ -88,6 +109,18 @@ function CreateCourse() {
           <option value="">Select Grade</option>
           {[...Array(13)].map((_, i) => (
             <option key={i + 1} value={i + 1}>Grade {i + 1}</option>
+          ))}
+        </select>
+        <select
+          className="form-control mb-2"
+          name="subject"
+          value={form.subject}
+          onChange={handleChange}
+          required
+        >
+          <option value="">Select Subject</option>
+          {subjects.map((s) => (
+            <option key={s} value={s}>{s}</option>
           ))}
         </select>
         <select

--- a/frontend/src/pages/Admin/CreateTeacher.jsx
+++ b/frontend/src/pages/Admin/CreateTeacher.jsx
@@ -3,7 +3,15 @@ import { useNavigate } from 'react-router-dom';
 import api from '../../api';
 
 function CreateTeacher() {
-  const [form, setForm] = useState({ firstName: '', lastName: '', email: '', phoneNumber: '', description: '', grade: '' });
+  const [form, setForm] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    phoneNumber: '',
+    description: '',
+    grade: '',
+    subject: ''
+  });
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
 
@@ -37,6 +45,14 @@ function CreateTeacher() {
             <option key={i + 1} value={i + 1}>Grade {i + 1}</option>
           ))}
         </select>
+        <input
+          className="form-control mb-2"
+          name="subject"
+          placeholder="Subject"
+          value={form.subject}
+          onChange={handleChange}
+          required
+        />
         <textarea className="form-control mb-2" name="description" placeholder="Description" value={form.description} onChange={handleChange} />
         <button className="btn btn-primary">Create</button>
       </form>

--- a/frontend/src/pages/Admin/EditTeacher.jsx
+++ b/frontend/src/pages/Admin/EditTeacher.jsx
@@ -4,7 +4,15 @@ import api from '../../api';
 
 function EditTeacher() {
   const { teacherId } = useParams();
-  const [form, setForm] = useState({ firstName: '', lastName: '', email: '', phoneNumber: '', description: '', grade: '' });
+  const [form, setForm] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    phoneNumber: '',
+    description: '',
+    grade: '',
+    subject: ''
+  });
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
 
@@ -44,6 +52,14 @@ function EditTeacher() {
             <option key={i + 1} value={i + 1}>Grade {i + 1}</option>
           ))}
         </select>
+        <input
+          className="form-control mb-2"
+          name="subject"
+          placeholder="Subject"
+          value={form.subject}
+          onChange={handleChange}
+          required
+        />
         <textarea className="form-control mb-2" name="description" placeholder="Description" value={form.description} onChange={handleChange} />
         <button className="btn btn-primary">Save</button>
       </form>

--- a/frontend/src/pages/Admin/TeacherList.jsx
+++ b/frontend/src/pages/Admin/TeacherList.jsx
@@ -32,7 +32,11 @@ function TeacherList() {
       <ul className="list-group">
         {teachers.map(t => (
           <li key={t._id} className="list-group-item d-flex justify-content-between">
-            <span>{t.firstName} {t.lastName} {t.grade ? `(Grade ${t.grade})` : ''}</span>
+            <span>
+              {t.firstName} {t.lastName}
+              {t.grade ? ` (Grade ${t.grade})` : ''}
+              {t.subject ? ` - ${t.subject}` : ''}
+            </span>
             <span>
               <Link className="btn btn-sm btn-outline-primary me-2" to={`/admin/teachers/${t._id}/edit`}>Edit</Link>
               <button className="btn btn-sm btn-outline-danger" onClick={() => deleteTeacher(t._id)}>Delete</button>

--- a/frontend/src/pages/Classes/GradeList.jsx
+++ b/frontend/src/pages/Classes/GradeList.jsx
@@ -17,7 +17,7 @@ const GradeList = () => {
       <h4>Choose a Grade</h4>
       <ul className="list-group">
         {grades.map(g => (
-          <Link key={g} to={`/classes/${g}/teachers`} className="list-group-item">
+          <Link key={g} to={`/classes/${g}/subjects`} className="list-group-item">
             Grade {g}
           </Link>
         ))}

--- a/frontend/src/pages/Classes/SubjectList.jsx
+++ b/frontend/src/pages/Classes/SubjectList.jsx
@@ -1,25 +1,29 @@
 import { useParams, Link } from 'react-router-dom';
-
-const subjects = [
-  { _id: 'sub-math', name: 'Mathematics' },
-  { _id: 'sub-science', name: 'Science' },
-  { _id: 'sub-english', name: 'English' },
-];
+import { useEffect, useState } from 'react';
+import api from '../../api';
 
 const SubjectList = () => {
   const { gradeId } = useParams();
+  const [subjects, setSubjects] = useState([]);
+
+  useEffect(() => {
+    api
+      .get(`/teachers/available-subjects?grade=${gradeId}`)
+      .then((res) => setSubjects(res.data.subjects || []))
+      .catch(() => setSubjects([]));
+  }, [gradeId]);
 
   return (
     <div className="container py-4">
       <h4>Select a Subject</h4>
       <ul className="list-group">
-        {subjects.map(subject => (
+        {subjects.map((subject) => (
           <Link
-            key={subject._id}
-            to={`/classes/${gradeId}/${subject._id}/teachers`}
+            key={subject}
+            to={`/classes/${gradeId}/subjects/${encodeURIComponent(subject)}/teachers`}
             className="list-group-item"
           >
-            {subject.name}
+            {subject}
           </Link>
         ))}
       </ul>

--- a/frontend/src/pages/Classes/TeacherCourses.jsx
+++ b/frontend/src/pages/Classes/TeacherCourses.jsx
@@ -3,7 +3,7 @@ import { useParams, Link } from 'react-router-dom';
 import api from '../../api';
 
 const TeacherCourses = () => {
-  const { gradeId, teacherId } = useParams();
+  const { gradeId, subjectName, teacherId } = useParams();
   const [teacher, setTeacher] = useState(null);
   const [courses, setCourses] = useState([]);
 
@@ -16,10 +16,12 @@ const TeacherCourses = () => {
   useEffect(() => {
     if (!teacher) return;
     const name = `${teacher.firstName} ${teacher.lastName}`;
-    api.get(`/courses?grade=${gradeId}&teacherName=${encodeURIComponent(name)}`)
+    let url = `/courses?grade=${gradeId}&teacherName=${encodeURIComponent(name)}`;
+    if (subjectName) url += `&subject=${encodeURIComponent(subjectName)}`;
+    api.get(url)
       .then(res => setCourses(res.data.courses || []))
       .catch(() => setCourses([]));
-  }, [gradeId, teacher]);
+  }, [gradeId, subjectName, teacher]);
 
   if (!teacher) return <div className="container py-4">Loading...</div>;
 

--- a/frontend/src/pages/Classes/TeacherList.jsx
+++ b/frontend/src/pages/Classes/TeacherList.jsx
@@ -3,15 +3,16 @@ import { useParams, Link } from 'react-router-dom';
 import api from '../../api';
 
 const TeacherList = () => {
-  const { gradeId } = useParams();
+  const { gradeId, subjectName } = useParams();
   const [teachers, setTeachers] = useState([]);
 
   useEffect(() => {
+    const query = `/teachers?grade=${gradeId}` + (subjectName ? `&subject=${encodeURIComponent(subjectName)}` : '');
     api
-      .get(`/teachers?grade=${gradeId}`)
+      .get(query)
       .then(res => setTeachers(res.data.teachers || []))
       .catch(() => setTeachers([]));
-  }, [gradeId]);
+  }, [gradeId, subjectName]);
 
   return (
     <div className="container py-4">
@@ -20,7 +21,7 @@ const TeacherList = () => {
         {teachers.map(t => (
           <Link
             key={t._id}
-            to={`/classes/${gradeId}/teachers/${t._id}`}
+            to={`/classes/${gradeId}/subjects/${encodeURIComponent(subjectName || '')}/teachers/${t._id}`}
             className="list-group-item"
           >
             {t.firstName} {t.lastName}


### PR DESCRIPTION
## Summary
- allow teachers to have subjects
- enable filtering teachers by subject and expose available subjects endpoint
- expand admin interfaces to manage teacher subjects and create courses by grade/subject/teacher
- add subject selection into class browsing flow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b04552ec832287b89f47492c03f6