### PR TITLE
Implement SMS OTP step for registration

### DIFF
--- a/frontend/src/pages/Auth/Register.jsx
+++ b/frontend/src/pages/Auth/Register.jsx
@@ -11,19 +11,51 @@ const Register = () => {
     education: '',
     address: ''
   });
+  const [otp, setOtp] = useState('');
+  const [otpSent, setOtpSent] = useState(false);
+  const [verified, setVerified] = useState(false);
   const [msg, setMsg] = useState('');
 
   const handleChange = (e) => {
     setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
   };
 
+  const sendOtp = async () => {
+    setMsg('');
+    try {
+      await api.post('/auth/send-otp', { phoneNumber: form.phoneNumber });
+      setOtpSent(true);
+      setMsg('OTP sent. Please check your phone.');
+    } catch (err) {
+      setMsg(err.response?.data?.message || 'Failed to send OTP.');
+    }
+  };
+
+  const verifyOtp = async () => {
+    setMsg('');
+    try {
+      await api.post('/auth/verify-reg-otp', {
+        phoneNumber: form.phoneNumber,
+        otp
+      });
+      setVerified(true);
+      setMsg('Phone number verified.');
+    } catch (err) {
+      setMsg(err.response?.data?.message || 'Failed to verify OTP.');
+    }
+  };
+
   const handleRegister = async (e) => {
     e.preventDefault();
+    if (!verified) {
+      setMsg('Please verify your phone number first.');
+      return;
+    }
     try {
       await api.post('/auth/register', form);
       setMsg('Registered successfully! You can now login.');
     } catch (err) {
-      setMsg('Registration failed.');
+      setMsg(err.response?.data?.message || 'Registration failed.');
     }
   };
 
@@ -31,7 +63,7 @@ const Register = () => {
     <div className="container py-5">
       <h3>Register</h3>
       <form onSubmit={handleRegister}>
-        {['firstName', 'lastName', 'phoneNumber', 'password', 'confirmPassword', 'education', 'address'].map(field => (
+        {['firstName', 'lastName', 'password', 'confirmPassword', 'education', 'address'].map(field => (
           <input
             key={field}
             name={field}
@@ -42,6 +74,35 @@ const Register = () => {
             required
           />
         ))}
+
+        <div className="input-group mb-2">
+          <input
+            name="phoneNumber"
+            className="form-control"
+            type="text"
+            placeholder="Phone Number"
+            onChange={handleChange}
+            required
+          />
+          <button type="button" className="btn btn-outline-secondary" onClick={sendOtp}>
+            Send OTP
+          </button>
+        </div>
+
+        {otpSent && !verified && (
+          <div className="input-group mb-2">
+            <input
+              className="form-control"
+              value={otp}
+              onChange={(e) => setOtp(e.target.value)}
+              placeholder="Enter OTP"
+            />
+            <button type="button" className="btn btn-outline-secondary" onClick={verifyOtp}>
+              Verify
+            </button>
+          </div>
+        )}
+
         <button className="btn btn-success">Register</button>
         {msg && <div className="alert alert-info mt-3">{msg}</div>}
       </form>


### PR DESCRIPTION
## Summary
- enable OTP verification before registering
- update registration UI to handle sending and verifying QuickSend OTP codes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857bcca878c83229afb2c40ee8e63bc