### PR TITLE
Add vibrant wave theme

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -12,16 +12,16 @@ const Navbar = () => {
   return (
     <nav className="navbar navbar-expand-lg navbar-custom shadow-sm">
       <div className="container">
-        <Link className="navbar-brand text-white" to="/">SmartBank</Link>
+        <Link className="navbar-brand text-white fw-bold" to="/">SmartBank</Link>
         <div className="ms-auto">
           {user ? (
-            <button className="btn btn-sm btn-light" onClick={handleLogout}>
+            <button className="btn btn-sm btn-light text-primary" onClick={handleLogout}>
               Logout
             </button>
           ) : (
             <>
-              <Link to="/login" className="btn btn-light btn-sm me-2">Login</Link>
-              <Link to="/register" className="btn btn-outline-light btn-sm">Register</Link>
+              <Link to="/login" className="btn btn-light btn-sm me-2 text-primary">Login</Link>
+              <Link to="/register" className="btn btn-outline-light btn-sm text-primary">Register</Link>
             </>
           )}
         </div>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import './bank-theme.css';
+import './wave-theme.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -5,11 +5,14 @@ const Home = () => {
 
   return (
     <div className="container py-5">
-      <div className="mb-4">
-        <h2 className="mb-1">Welcome to the Learning Platform</h2>
+      <div className="hero">
+        <h2 className="mb-2">Welcome to the Learning Platform</h2>
         {user && (
-          <p className="text-muted mb-0">Hello, {user.firstName} {user.lastName}</p>
+          <p className="mb-0">Hello, {user.firstName} {user.lastName}</p>
         )}
+      </div>
+      <div className="text-center mb-4">
+        <h4 className="fw-semibold">Quick Access</h4>
       </div>
 
       <div className="row gy-4">

--- a/frontend/src/wave-theme.css
+++ b/frontend/src/wave-theme.css
@@ -1,0 +1,50 @@
+:root {
+  --wave-primary: #2a7de1;
+  --wave-secondary: #f05a28;
+  --wave-bg: #eef5fd;
+  --wave-text: #333;
+}
+
+body {
+  background-color: var(--wave-bg);
+  color: var(--wave-text);
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+}
+
+.navbar-custom {
+  background: linear-gradient(90deg, var(--wave-primary), var(--wave-secondary));
+}
+
+.tile-link {
+  color: #fff;
+}
+.tile-link:hover {
+  color: #fff;
+  text-decoration: none;
+}
+
+.tile {
+  background: linear-gradient(135deg, var(--wave-primary), var(--wave-secondary));
+  color: #fff;
+  border: none;
+  transition: transform 0.2s, box-shadow 0.2s;
+  border-radius: 12px;
+}
+.tile:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(0,0,0,0.15);
+}
+
+.tile-icon {
+  font-size: 3rem;
+}
+
+.hero {
+  background: linear-gradient(135deg, var(--wave-primary), var(--wave-secondary));
+  color: #fff;
+  padding: 4rem 2rem;
+  border-radius: 12px;
+  text-align: center;
+  margin-bottom: 2rem;
+}
+


### PR DESCRIPTION
## Summary
- add colourful `wave-theme.css`
- update Navbar look
- add hero section and improved Home page
- use wave theme by default

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c664f8f48322af6db49b28bbfc6a