### PR TITLE
Restrict course detail response for unpaid students

### DIFF
--- a/backend/controllers/courseController.js
+++ b/backend/controllers/courseController.js
@@ -88,19 +88,9 @@ exports.getCourseById = async (req, res) => {
 
     const courseObj = course.toObject();
     if (!hasAccess) {
-      courseObj.courseContent = courseObj.courseContent.map((c) => {
-        if (c.isPublic) {
-          return {
-            title: c.title,
-            videoId: c.videoId,
-            videoUrl: c.videoUrl,
-            isPublic: c.isPublic,
-            visibleFrom: c.visibleFrom,
-            subtitles: c.subtitles
-          };
-        }
-        return { title: c.title };
-      });
+      courseObj.courseContent = courseObj.courseContent.map((c) => ({
+        title: c.title,
+      }));
     }
 
     res.json({ message: 'Course retrieved successfully', course: courseObj, hasAccess });


### PR DESCRIPTION
## Summary
- simplify course content returned when the user lacks access

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint module not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9edf99a083229a70eb1b8f4215dd