### PR TITLE
Add full course update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ and optional subtitles. The `isPublic` flag determines whether a video is free
 for unpaid students or restricted to enrolled users. The older file upload
 endpoint is no longer used by the dashboard.
 
+### Updating full course details
+
+Admins can replace all information and video metadata for a course in a single
+request using:
+
+```
+PUT /api/courses/:id/full
+```
+
+Include regular course fields (`title`, `description`, etc.) and an array
+`courseContent`. Each content item accepts `isPublic` as a toggle: when `true`
+the video is available for free, otherwise it requires enrollment.
+
 Requests to `/api/courses/:id/content` must include a valid Bearer token.
 Attempting to open the endpoint in a browser with a `GET` request will result in
 `Cannot GET /api/...`.

--- a/backend/controllers/courseController.js
+++ b/backend/controllers/courseController.js
@@ -146,6 +146,55 @@ exports.updateCourse = async (req, res) => {
   }
 };
 
+// Update an entire course including its content array
+exports.updateFullCourse = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const {
+      title,
+      description,
+      price,
+      durationInDays,
+      type,
+      grade,
+      subject,
+      teacherName,
+      courseContent
+    } = req.body;
+
+    const course = await Course.findById(id);
+    if (!course) return res.status(404).json({ message: 'Course not found' });
+
+    if (title !== undefined) course.title = title;
+    if (description !== undefined) course.description = description;
+    if (price !== undefined) course.price = parseFloat(price);
+    if (durationInDays !== undefined) course.durationInDays = durationInDays;
+    if (type !== undefined) course.type = type;
+    if (grade !== undefined) course.grade = grade;
+    if (subject !== undefined) course.subject = subject;
+    if (teacherName !== undefined) course.teacherName = teacherName;
+
+    if (Array.isArray(courseContent)) {
+      course.courseContent = courseContent.map((c) => ({
+        title: c.title,
+        videoId: c.videoId,
+        videoUrl: c.videoUrl,
+        isPublic: !!c.isPublic,
+        visibleFrom: c.visibleFrom ? new Date(c.visibleFrom) : null,
+        subtitles: Array.isArray(c.subtitles)
+          ? c.subtitles.map((s) => ({ language: s.language, url: s.url }))
+          : []
+      }));
+    }
+
+    await course.save();
+    res.json({ message: 'Course updated successfully', course });
+  } catch (error) {
+    console.error('Update full course error:', error);
+    res.status(500).json({ message: 'Update failed', error: error.message });
+  }
+};
+
 // Delete course
 exports.deleteCourse = async (req, res) => {
   try {

--- a/backend/routes/courseRoutes.js
+++ b/backend/routes/courseRoutes.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const courseController = require('../controllers/courseController');
 const videoController = require('../controllers/uploadCourseVideo');
 const upload = require('../middleware/upload');
-const { authenticateToken } = require('../middleware/authMiddleware');
+const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
 
 // Course CRUD
 router.post('/courses', authenticateToken, courseController.createCourse);
@@ -13,6 +13,7 @@ router.get('/courses/available-grades', courseController.getAvailableGrades);
 router.get('/courses/:id', courseController.getCourseById);
 router.put('/courses/:id', authenticateToken, courseController.updateCourse);
 router.delete('/courses/:id', authenticateToken, courseController.deleteCourse);
+router.put('/courses/:id/full', authenticateToken, requireAdmin, courseController.updateFullCourse);
 
 // Add course content (manual embed or Bunny.net metadata)
 router.post('/courses/:id/content', authenticateToken, courseController.addCourseContent);


### PR DESCRIPTION
## Summary
- add `/courses/:id/full` route to let admins update all course details
- document new endpoint in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba55919a8832289c57e4e93e30cab