### PR TITLE
Improve video access toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Include regular course fields (`title`, `description`, etc.) and an array
 `courseContent`. Each content item accepts `isPublic` as a toggle: when `true`
 the video is available for free, otherwise it requires enrollment.
 
+The admin dashboard now uses a pair of radio buttons labelled
+"Allow access for unpaid students" and "Restrict to paid students" when
+adding or editing course videos. Subtitle URL inputs are validated to ensure
+they contain a valid `.vtt` link whenever subtitles are enabled.
+
 Requests to `/api/courses/:id/content` must include a valid Bearer token.
 Attempting to open the endpoint in a browser with a `GET` request will result in
 `Cannot GET /api/...`.

--- a/frontend/src/components/UploadCourseContent.jsx
+++ b/frontend/src/components/UploadCourseContent.jsx
@@ -15,6 +15,15 @@ function UploadCourseContent({ courseId }) {
   const [showSubtitles, setShowSubtitles] = useState(false);
   const [message, setMessage] = useState('');
 
+  const isValidUrl = (value) => {
+    try {
+      new URL(value);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
   // Load existing course content
   useEffect(() => {
     api
@@ -40,6 +49,18 @@ function UploadCourseContent({ courseId }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
+      if (showSubtitles) {
+        for (const sub of form.subtitles) {
+          if (!sub.language || !sub.url) {
+            setMessage('Subtitle language and URL are required');
+            return;
+          }
+          if (!isValidUrl(sub.url) || !sub.url.endsWith('.vtt')) {
+            setMessage('Subtitle URL must be a valid link ending with .vtt');
+            return;
+          }
+        }
+      }
       if (editingId) {
         await api.put(`/courses/${courseId}/content/${editingId}`, form);
         setMessage('Video updated.');
@@ -145,17 +166,33 @@ function UploadCourseContent({ courseId }) {
         />
         <input type="datetime-local" name="visibleFrom" value={form.visibleFrom} onChange={handleChange}
                className="form-control mb-2" />
-        <div className="form-check mb-2">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            name="isPublic"
-            checked={form.isPublic}
-            onChange={(e) => setForm({ ...form, isPublic: e.target.checked })}
-          />
-          <label className="form-check-label">
-            Allow access for unpaid students
-          </label>
+        <div className="mb-2">
+          <div className="form-check">
+            <input
+              className="form-check-input"
+              type="radio"
+              name="isPublic"
+              id="isPublicYes"
+              checked={form.isPublic}
+              onChange={() => setForm({ ...form, isPublic: true })}
+            />
+            <label className="form-check-label" htmlFor="isPublicYes">
+              Allow access for unpaid students
+            </label>
+          </div>
+          <div className="form-check">
+            <input
+              className="form-check-input"
+              type="radio"
+              name="isPublic"
+              id="isPublicNo"
+              checked={!form.isPublic}
+              onChange={() => setForm({ ...form, isPublic: false })}
+            />
+            <label className="form-check-label" htmlFor="isPublicNo">
+              Restrict to paid students
+            </label>
+          </div>
         </div>
 
         <div className="form-check form-switch mb-2">


### PR DESCRIPTION
## Summary
- convert admin video access checkbox to radio buttons
- validate subtitle URL inputs before submit
- mention new radio buttons and validation in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in `frontend` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685ba9aa66ec8322aebbdf82f1cc5915