### PR TITLE
Ensure paid access check for recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The admin dashboard now uses a pair of radio buttons labelled
 adding or editing course videos. Subtitle URL inputs are validated to ensure
 they contain a valid `.vtt` link whenever subtitles are enabled.
 
+Students who are not enrolled will only see videos and subtitles when the
+"Allow access for unpaid students" option is selected on that content item.
+
 Requests to `/api/courses/:id/content` must include a valid Bearer token.
 Attempting to open the endpoint in a browser with a `GET` request will result in
 `Cannot GET /api/...`.

--- a/frontend/src/pages/Dashboard/Recordings.jsx
+++ b/frontend/src/pages/Dashboard/Recordings.jsx
@@ -6,6 +6,7 @@ function Recordings() {
   const { classId } = useParams();
   const [course, setCourse] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [hasAccess, setHasAccess] = useState(false);
   const [now] = useState(new Date());
 
   useEffect(() => {
@@ -15,6 +16,7 @@ function Recordings() {
     })
     .then(res => {
       setCourse(res.data.course);
+      setHasAccess(res.data.hasAccess || false);
       setLoading(false);
     })
     .catch(() => setLoading(false));
@@ -30,7 +32,8 @@ function Recordings() {
       {course.courseContent?.length === 0 && <p>No videos available</p>}
 
       {course.courseContent?.map((video, index) => {
-        const isVisible = video.isPublic || new Date(video.visibleFrom) <= now;
+        const isVisible =
+          hasAccess || video.isPublic || new Date(video.visibleFrom) <= now;
 
         return (
           <div key={index} className="mb-5 border p-3 rounded">


### PR DESCRIPTION
## Summary
- respect course access when displaying recordings
- clarify README that non-enrolled users only see public content

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bac12c04483229289e791ae0af505