### PR TITLE
Fix free content display

### DIFF
--- a/frontend/src/pages/Classes/ClassDetail.jsx
+++ b/frontend/src/pages/Classes/ClassDetail.jsx
@@ -138,7 +138,10 @@ const ClassDetail = () => {
           </div>
         )}
 
-      {classData.courseContent?.map((video, index) => {
+      {(hasAccess
+        ? classData.courseContent
+        : classData.courseContent?.filter(v => v.videoUrl)
+      )?.map((video, index) => {
         const hasVideo = !!video.videoUrl;
         const isVisible =
           hasAccess ||


### PR DESCRIPTION
## Summary
- filter class videos so unpaid users only see free and available content

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc17c975c83229d5457a3f148dd28