### PR TITLE
Add admin notices feature

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -15,6 +15,7 @@ const paymentRoutes = require('./routes/paymentRoutes');
 const bankPaymentRoutes = require('./routes/bankPaymentRoutes');
 const bunnyRoutes = require('./routes/bunnyRoutes');
 const teacherRoutes = require('./routes/teacherRoutes');
+const noticeRoutes = require('./routes/noticeRoutes');
 
 const app = express();
 
@@ -44,6 +45,7 @@ app.use('/api/bank-payment', bankPaymentRoutes);
 app.use('/api', courseRoutes);
 app.use('/api', bunnyRoutes);
 app.use('/api/teachers', teacherRoutes);
+app.use('/api/notices', noticeRoutes);
 
 // Connect to MongoDB (removed deprecated options)
 mongoose.connect(process.env.MONGO_URI)

--- a/backend/controllers/noticeController.js
+++ b/backend/controllers/noticeController.js
@@ -1,0 +1,44 @@
+const Notice = require('../models/Notice');
+
+exports.createNotice = async (req, res) => {
+  try {
+    const { title, message, courseId, teacherId } = req.body;
+
+    if (!title || !message) {
+      return res.status(400).json({ message: 'Title and message are required' });
+    }
+
+    if (!courseId && !teacherId) {
+      return res.status(400).json({ message: 'Course or teacher must be specified' });
+    }
+
+    const notice = new Notice({
+      title,
+      message,
+      courseId,
+      teacherId,
+      createdBy: req.user?.userId
+    });
+
+    await notice.save();
+    res.status(201).json({ notice });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to create notice' });
+  }
+};
+
+exports.getNotices = async (req, res) => {
+  try {
+    const { courseId, teacherId } = req.query;
+    const query = { isActive: true };
+    if (courseId) query.courseId = courseId;
+    if (teacherId) query.teacherId = teacherId;
+
+    const notices = await Notice.find(query).sort({ createdAt: -1 });
+    res.json({ notices });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to fetch notices' });
+  }
+};

--- a/backend/models/Notice.js
+++ b/backend/models/Notice.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const noticeSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  message: { type: String, required: true },
+  courseId: { type: mongoose.Schema.Types.ObjectId, ref: 'Course' },
+  teacherId: { type: mongoose.Schema.Types.ObjectId, ref: 'Teacher' },
+  createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  isActive: { type: Boolean, default: true }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Notice', noticeSchema);

--- a/backend/routes/noticeRoutes.js
+++ b/backend/routes/noticeRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/noticeController');
+const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
+
+router.post('/', authenticateToken, requireAdmin, controller.createNotice);
+router.get('/', controller.getNotices);
+
+module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,8 @@ import BunnyVideoList from './pages/Admin/BunnyVideoList';
 import TeacherListAdmin from './pages/Admin/TeacherList';
 import CreateTeacher from './pages/Admin/CreateTeacher';
 import EditTeacher from './pages/Admin/EditTeacher';
+import NoticeList from './pages/Admin/NoticeList';
+import CreateNotice from './pages/Admin/CreateNotice';
 import RequireAdmin from './components/RequireAdmin';
 
 function App() {
@@ -92,6 +94,8 @@ function App() {
         <Route path="/admin/teachers" element={<RequireAdmin><TeacherListAdmin /></RequireAdmin>} />
         <Route path="/admin/teachers/create" element={<RequireAdmin><CreateTeacher /></RequireAdmin>} />
         <Route path="/admin/teachers/:teacherId/edit" element={<RequireAdmin><EditTeacher /></RequireAdmin>} />
+        <Route path="/admin/notices" element={<RequireAdmin><NoticeList /></RequireAdmin>} />
+        <Route path="/admin/notices/create" element={<RequireAdmin><CreateNotice /></RequireAdmin>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Admin/CreateNotice.jsx
+++ b/frontend/src/pages/Admin/CreateNotice.jsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../../api';
+
+function CreateNotice() {
+  const [form, setForm] = useState({
+    title: '',
+    message: '',
+    courseId: '',
+    teacherId: ''
+  });
+  const [courses, setCourses] = useState([]);
+  const [teachers, setTeachers] = useState([]);
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    api.get('/courses')
+      .then(res => setCourses(res.data.courses || []))
+      .catch(() => setCourses([]));
+    api.get('/teachers')
+      .then(res => setTeachers(res.data.teachers || []))
+      .catch(() => setTeachers([]));
+  }, []);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post('/notices', form);
+      setMessage('Notice created');
+      navigate('/admin/notices');
+    } catch (err) {
+      setMessage('Creation failed');
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h2>Create Notice</h2>
+      {message && <div className="alert alert-info">{message}</div>}
+      <form onSubmit={handleSubmit}>
+        <input
+          className="form-control mb-2"
+          name="title"
+          placeholder="Title"
+          value={form.title}
+          onChange={handleChange}
+          required
+        />
+        <textarea
+          className="form-control mb-2"
+          name="message"
+          placeholder="Message"
+          value={form.message}
+          onChange={handleChange}
+          required
+        />
+        <select
+          className="form-control mb-2"
+          name="courseId"
+          value={form.courseId}
+          onChange={handleChange}
+        >
+          <option value="">Select Class (optional)</option>
+          {courses.map(c => (
+            <option key={c._id} value={c._id}>{c.title}</option>
+          ))}
+        </select>
+        <select
+          className="form-control mb-2"
+          name="teacherId"
+          value={form.teacherId}
+          onChange={handleChange}
+        >
+          <option value="">Select Teacher (optional)</option>
+          {teachers.map(t => (
+            <option key={t._id} value={t._id}>{t.firstName} {t.lastName}</option>
+          ))}
+        </select>
+        <button className="btn btn-primary">Create</button>
+      </form>
+    </div>
+  );
+}
+
+export default CreateNotice;

--- a/frontend/src/pages/Admin/NoticeList.jsx
+++ b/frontend/src/pages/Admin/NoticeList.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../../api';
+
+function NoticeList() {
+  const [notices, setNotices] = useState([]);
+
+  const load = () => {
+    api.get('/notices')
+      .then(res => setNotices(res.data.notices || []))
+      .catch(() => setNotices([]));
+  };
+
+  useEffect(() => { load(); }, []);
+
+  return (
+    <div className="container mt-4">
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <h2>Notices</h2>
+        <Link className="btn btn-success" to="/admin/notices/create">New Notice</Link>
+      </div>
+      <ul className="list-group">
+        {notices.map(n => (
+          <li key={n._id} className="list-group-item">
+            <strong>{n.title}</strong>
+            <p className="mb-0">{n.message}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default NoticeList;

--- a/frontend/src/pages/Dashboard/Recordings.jsx
+++ b/frontend/src/pages/Dashboard/Recordings.jsx
@@ -7,6 +7,7 @@ function Recordings() {
   const [course, setCourse] = useState(null);
   const [loading, setLoading] = useState(true);
   const [now] = useState(new Date());
+  const [notices, setNotices] = useState([]);
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -18,6 +19,10 @@ function Recordings() {
       setLoading(false);
     })
     .catch(() => setLoading(false));
+
+    axios.get(`http://localhost:5000/api/notices?courseId=${classId}`)
+      .then(res => setNotices(res.data.notices || []))
+      .catch(() => setNotices([]));
   }, [classId]);
 
   if (loading) return <div className="container mt-5">Loading...</div>;
@@ -26,6 +31,16 @@ function Recordings() {
   return (
     <div className="container mt-4">
       <h3>{course.title} - Recordings</h3>
+
+      {notices.length > 0 && (
+        <div className="alert alert-warning">
+          {notices.map(n => (
+            <div key={n._id}>
+              <strong>{n.title}:</strong> {n.message}
+            </div>
+          ))}
+        </div>
+      )}
 
       {course.courseContent?.length === 0 && <p>No videos available</p>}
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -26,6 +26,7 @@ const Home = () => {
           <Tile title="Payments" icon="💳" link="/admin/payments" />
           <Tile title="Videos" icon="🎞️" link="/admin/videos" />
           <Tile title="Teachers" icon="🧑‍🏫" link="/admin/teachers" />
+          <Tile title="Notices" icon="📢" link="/admin/notices" />
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add Notice model and controller to post/get notices
- expose /api/notices route
- allow admins to create notices in dashboard
- list notices for admins and link from home page
- show relevant notices on student recordings page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc50cbe88832293ee2a1371f1992d