### PR TITLE
Implement student notices feature

### DIFF
--- a/backend/controllers/noticeController.js
+++ b/backend/controllers/noticeController.js
@@ -1,4 +1,7 @@
 const Notice = require('../models/Notice');
+const UserCourseAccess = require('../models/UserCourseAccess');
+const Course = require('../models/Course');
+const Teacher = require('../models/Teacher');
 
 exports.createNotice = async (req, res) => {
   try {
@@ -34,6 +37,47 @@ exports.getNotices = async (req, res) => {
     const query = { isActive: true };
     if (courseId) query.courseId = courseId;
     if (teacherId) query.teacherId = teacherId;
+
+    const notices = await Notice.find(query).sort({ createdAt: -1 });
+    res.json({ notices });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to fetch notices' });
+  }
+};
+
+exports.getMyNotices = async (req, res) => {
+  try {
+    const userId = req.user.userId;
+
+    // Active course access for this user
+    const accesses = await UserCourseAccess.find({
+      userId,
+      expiresAt: { $gt: new Date() }
+    }).populate('courseId');
+
+    const courseIds = accesses.map((a) => a.courseId?._id).filter(Boolean);
+    const teacherNames = accesses
+      .map((a) => a.courseId?.teacherName)
+      .filter(Boolean);
+
+    // Map teacher names to teacher IDs
+    const teachers = await Teacher.find({});
+    const teacherIdMap = new Map();
+    teachers.forEach((t) => {
+      teacherIdMap.set(`${t.firstName} ${t.lastName}`, t._id.toString());
+    });
+    const teacherIds = teacherNames
+      .map((name) => teacherIdMap.get(name))
+      .filter(Boolean);
+
+    const query = { isActive: true, $or: [] };
+    if (courseIds.length > 0) query.$or.push({ courseId: { $in: courseIds } });
+    if (teacherIds.length > 0) query.$or.push({ teacherId: { $in: teacherIds } });
+
+    if (query.$or.length === 0) {
+      return res.json({ notices: [] });
+    }
 
     const notices = await Notice.find(query).sort({ createdAt: -1 });
     res.json({ notices });

--- a/backend/routes/noticeRoutes.js
+++ b/backend/routes/noticeRoutes.js
@@ -5,5 +5,6 @@ const { authenticateToken, requireAdmin } = require('../middleware/authMiddlewar
 
 router.post('/', authenticateToken, requireAdmin, controller.createNotice);
 router.get('/', controller.getNotices);
+router.get('/my', authenticateToken, controller.getMyNotices);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,7 @@ import Assignments from './pages/Dashboard/Assignments';
 import Marks from './pages/Dashboard/Marks';
 import Attendance from './pages/Dashboard/Attendance';
 import PaymentHistory from './pages/Dashboard/PaymentHistory';
+import Notices from './pages/Dashboard/Notices';
 import ELibrary from './pages/ELibrary/ELibrary';
 import PaymentSuccess from './pages/PaymentSuccess';
 
@@ -74,6 +75,7 @@ function App() {
 
         {/* Dashboard */}
         <Route path="/dashboard" element={<MyClasses />} />
+        <Route path="/dashboard/notices" element={<Notices />} />
         <Route path="/dashboard/live/:classId" element={<LiveClasses />} />
         <Route path="/dashboard/recordings/:classId" element={<Recordings />} />
         <Route path="/dashboard/assignments/:classId" element={<Assignments />} />

--- a/frontend/src/pages/Dashboard/Notices.jsx
+++ b/frontend/src/pages/Dashboard/Notices.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+
+const Notices = () => {
+  const [notices, setNotices] = useState([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    api.get('/notices/my')
+      .then(res => {
+        setNotices(res.data.notices || []);
+        setLoaded(true);
+        if ((res.data.notices || []).length > 0) {
+          // simple notification
+          alert('You have new notices');
+        }
+      })
+      .catch(() => {
+        setLoaded(true);
+        setNotices([]);
+      });
+  }, []);
+
+  if (!loaded) return <div className="container py-4">Loading...</div>;
+
+  return (
+    <div className="container py-4">
+      <h4>Notices</h4>
+      {notices.length === 0 && <p className="text-muted">No notices</p>}
+      <ul className="list-group">
+        {notices.map(n => (
+          <li key={n._id} className="list-group-item">
+            <strong>{n.title}</strong> – {n.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Notices;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -19,6 +19,7 @@ const Home = () => {
         <Tile title="Classes" icon="🎓" link="/classes" />
         <Tile title="Shop" icon="🛒" link="/shop" />
         <Tile title="Student Dashboard" icon="📊" link="/dashboard" />
+        <Tile title="Notices" icon="📢" link="/dashboard/notices" />
         <Tile title="E-Library" icon="📚" link="/e-library" />
         {user?.userRole === 'admin' && (
           <>


### PR DESCRIPTION
## Summary
- support per-user notices on the backend
- expose `/api/notices/my` route
- create a Dashboard Notices page
- link the notices page from App routes and home tiles

## Testing
- `npm test --prefix backend` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bc6dcfba48322ae0212318b43f94e