### PR TITLE
Improve responsive shop page

### DIFF
--- a/frontend/src/pages/Shop/Cart.jsx
+++ b/frontend/src/pages/Shop/Cart.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import api from '../../api';
+import './shop.css';
 
 const Cart = () => {
   const [items, setItems] = useState([]);
@@ -47,22 +48,36 @@ const Cart = () => {
 
   return (
     <div className="container py-4">
-      <h3>Your Cart</h3>
+      <h3 className="mb-4 text-center">Shopping Cart</h3>
       {items.length === 0 ? (
-        <p>No items in cart.</p>
+        <p className="text-center">No items in cart.</p>
       ) : (
         <>
           <ul className="list-group mb-3">
             {items.map((item, idx) => (
-              <li key={idx} className="list-group-item d-flex justify-content-between">
-                {item.name} x {item.qty || 1}
-                <span>Rs. {item.price * (item.qty || 1)}</span>
+              <li
+                key={idx}
+                className="list-group-item d-flex justify-content-between align-items-center"
+              >
+                <div>
+                  {item.name} <span className="text-muted">x {item.qty || 1}</span>
+                </div>
+                <span className="fw-semibold">Rs. {item.price * (item.qty || 1)}</span>
               </li>
             ))}
           </ul>
-          <h5>Total: Rs. {total}</h5>
-          <button className="btn btn-success me-2" onClick={handleCheckout}>Checkout</button>
-          <button className="btn btn-outline-danger" onClick={clearCart}>Clear Cart</button>
+          <div className="d-flex justify-content-between align-items-center mb-3">
+            <h5 className="mb-0">Total:</h5>
+            <h5 className="mb-0">Rs. {total}</h5>
+          </div>
+          <div className="d-flex flex-column flex-sm-row gap-2">
+            <button className="btn btn-success flex-fill" onClick={handleCheckout}>
+              Checkout
+            </button>
+            <button className="btn btn-outline-danger flex-fill" onClick={clearCart}>
+              Clear Cart
+            </button>
+          </div>
         </>
       )}
     </div>

--- a/frontend/src/pages/Shop/Shop.jsx
+++ b/frontend/src/pages/Shop/Shop.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import api from '../../api';
+import './shop.css';
 
 const Shop = () => {
   const [cart, setCart] = useState(() => {
@@ -24,16 +25,25 @@ const Shop = () => {
 
   return (
     <div className="container py-4">
-      <h3>Shop Items</h3>
-      <div className="row">
-        {items.map(item => (
-          <div className="col-md-4" key={item._id}>
-            <div className="card mb-3">
-              {item.imageUrl && <img src={item.imageUrl} className="card-img-top" alt={item.name} />}
-              <div className="card-body">
-                <h5>{item.name}</h5>
-                <p>Rs. {item.price}</p>
-                <button className="btn btn-sm btn-primary" onClick={() => addToCart(item)}>
+      <h3 className="mb-4 text-center">Shop Items</h3>
+      <div className="row g-4">
+        {items.map((item) => (
+          <div className="col-12 col-sm-6 col-md-4 col-lg-3" key={item._id}>
+            <div className="card h-100 shadow-sm shop-card">
+              {item.imageUrl && (
+                <img
+                  src={item.imageUrl}
+                  className="card-img-top shop-card-img"
+                  alt={item.name}
+                />
+              )}
+              <div className="card-body d-flex flex-column">
+                <h5 className="card-title">{item.name}</h5>
+                <p className="card-text fw-semibold mb-3">Rs. {item.price}</p>
+                <button
+                  className="btn btn-primary mt-auto w-100"
+                  onClick={() => addToCart(item)}
+                >
                   Add to Cart
                 </button>
               </div>
@@ -41,7 +51,11 @@ const Shop = () => {
           </div>
         ))}
       </div>
-      <Link to="/shop/cart" className="btn btn-dark mt-3">Go to Cart</Link>
+      <div className="text-center mt-4">
+        <Link to="/shop/cart" className="btn btn-dark">
+          Go to Cart
+        </Link>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/Shop/shop.css
+++ b/frontend/src/pages/Shop/shop.css
@@ -1,0 +1,14 @@
+.shop-card-img {
+  height: 180px;
+  object-fit: cover;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+.shop-card {
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.shop-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
## Summary
- rework shop listings with a responsive grid
- tweak cart layout to be easier on mobile
- add custom styles for shop cards

## Testing
- `npm --prefix backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bceb3c310832287b3740603747bb0