### PR TITLE
Improve student dashboard UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import Shop from './pages/Shop/Shop';
 import Cart from './pages/Shop/Cart';
 
 // Student Dashboard
+import StudentDashboard from './pages/Dashboard/StudentDashboard';
 import MyClasses from './pages/Dashboard/MyClasses';
 import LiveClasses from './pages/Dashboard/LiveClasses';
 import Recordings from './pages/Dashboard/Recordings';
@@ -77,7 +78,8 @@ function App() {
         <Route path="/payment-success" element={<PaymentSuccess />} />
 
         {/* Dashboard */}
-        <Route path="/dashboard" element={<MyClasses />} />
+        <Route path="/dashboard" element={<StudentDashboard />} />
+        <Route path="/dashboard/classes" element={<MyClasses />} />
         <Route path="/dashboard/notices" element={<Notices />} />
         <Route path="/dashboard/live/:classId" element={<LiveClasses />} />
         <Route path="/dashboard/recordings/:classId" element={<Recordings />} />

--- a/frontend/src/pages/Dashboard/StudentDashboard.jsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.jsx
@@ -1,0 +1,25 @@
+import Tile from '../../components/Tile';
+
+const StudentDashboard = () => {
+  const user = JSON.parse(localStorage.getItem('user'));
+
+  return (
+    <div className="container py-5">
+      <div className="hero">
+        <h2 className="mb-2">Student Dashboard</h2>
+        {user && (
+          <p className="mb-0">Welcome back, {user.firstName} {user.lastName}</p>
+        )}
+      </div>
+
+      <div className="row gy-4">
+        <Tile title="My Classes" icon="\uD83D\uDCDA" link="/dashboard/classes" />
+        <Tile title="Payment History" icon="\uD83D\uDCB3" link="/dashboard/payments" />
+        <Tile title="Attendance" icon="\u2705" link="/dashboard/attendance" />
+        <Tile title="Notices" icon="\uD83D\uDCE2" link="/dashboard/notices" />
+      </div>
+    </div>
+  );
+};
+
+export default StudentDashboard;


### PR DESCRIPTION
## Summary
- add StudentDashboard component with quick-access tiles
- route `/dashboard` to new overview page
- show enrolled classes at `/dashboard/classes`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in frontend *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bd231c718832289ac036dc37af981