### PR TITLE
Add recordings and assignments sections to dashboard

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,8 @@ import MyClasses from './pages/Dashboard/MyClasses';
 import LiveClasses from './pages/Dashboard/LiveClasses';
 import Recordings from './pages/Dashboard/Recordings';
 import Assignments from './pages/Dashboard/Assignments';
+import MyRecordings from './pages/Dashboard/MyRecordings';
+import MyAssignments from './pages/Dashboard/MyAssignments';
 import Marks from './pages/Dashboard/Marks';
 import Attendance from './pages/Dashboard/Attendance';
 import PaymentHistory from './pages/Dashboard/PaymentHistory';
@@ -80,6 +82,8 @@ function App() {
         {/* Dashboard */}
         <Route path="/dashboard" element={<StudentDashboard />} />
         <Route path="/dashboard/classes" element={<MyClasses />} />
+        <Route path="/dashboard/recordings" element={<MyRecordings />} />
+        <Route path="/dashboard/assignments" element={<MyAssignments />} />
         <Route path="/dashboard/notices" element={<Notices />} />
         <Route path="/dashboard/live/:classId" element={<LiveClasses />} />
         <Route path="/dashboard/recordings/:classId" element={<Recordings />} />

--- a/frontend/src/pages/Dashboard/MyAssignments.jsx
+++ b/frontend/src/pages/Dashboard/MyAssignments.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+import { Link } from 'react-router-dom';
+
+const MyAssignments = () => {
+  const [classes, setClasses] = useState([]);
+
+  useEffect(() => {
+    api.get('/users/my-courses')
+      .then(res => setClasses(res.data.classes || []))
+      .catch(err => console.error('Failed to load classes:', err));
+  }, []);
+
+  const now = new Date();
+
+  return (
+    <div className="container py-4">
+      <h4>📝 Assignments</h4>
+
+      {classes.length === 0 && (
+        <p className="text-muted">No classes enrolled yet.</p>
+      )}
+
+      <ul className="list-group">
+        {classes.map((cls) => {
+          const isExpired = cls.expiresAt && new Date(cls.expiresAt) < now;
+
+          return (
+            <li
+              key={cls._id}
+              className="list-group-item d-flex justify-content-between align-items-center"
+            >
+              <div>
+                <strong>{cls.title}</strong>
+                {isExpired && (
+                  <span className="badge bg-danger ms-2">Expired</span>
+                )}
+              </div>
+              <Link
+                to={`/dashboard/assignments/${cls._id}`}
+                className="btn btn-sm btn-outline-primary"
+              >
+                View Assignments
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default MyAssignments;

--- a/frontend/src/pages/Dashboard/MyRecordings.jsx
+++ b/frontend/src/pages/Dashboard/MyRecordings.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+import { Link } from 'react-router-dom';
+
+const MyRecordings = () => {
+  const [classes, setClasses] = useState([]);
+
+  useEffect(() => {
+    api.get('/users/my-courses')
+      .then(res => setClasses(res.data.classes || []))
+      .catch(err => console.error('Failed to load classes:', err));
+  }, []);
+
+  const now = new Date();
+
+  return (
+    <div className="container py-4">
+      <h4>🎥 Recordings</h4>
+
+      {classes.length === 0 && (
+        <p className="text-muted">No classes enrolled yet.</p>
+      )}
+
+      <ul className="list-group">
+        {classes.map((cls) => {
+          const isExpired = cls.expiresAt && new Date(cls.expiresAt) < now;
+
+          return (
+            <li
+              key={cls._id}
+              className="list-group-item d-flex justify-content-between align-items-center"
+            >
+              <div>
+                <strong>{cls.title}</strong>
+                {isExpired && (
+                  <span className="badge bg-danger ms-2">Expired</span>
+                )}
+              </div>
+              <Link
+                to={`/dashboard/recordings/${cls._id}`}
+                className="btn btn-sm btn-outline-primary"
+              >
+                View Recordings
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default MyRecordings;

--- a/frontend/src/pages/Dashboard/StudentDashboard.jsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.jsx
@@ -20,6 +20,8 @@ const StudentDashboard = () => {
       <div className="row gy-4 dashboard-tiles">
         <Tile title="My Classes" icon="📚" link="/dashboard/classes" />
         <Tile title="Payment History" icon="💳" link="/dashboard/payments" />
+        <Tile title="Recordings" icon="🎥" link="/dashboard/recordings" />
+        <Tile title="Assignments" icon="📝" link="/dashboard/assignments" />
         <Tile title="Attendance" icon="✅" link="/dashboard/attendance" />
         <Tile title="Notices" icon="📢" link="/dashboard/notices" />
       </div>


### PR DESCRIPTION
## Summary
- show new quick links for recordings and assignments
- create MyRecordings and MyAssignments pages
- route new pages from App

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bda5bd5a08322b4fb097ac70df167