### PR TITLE
Redesign admin course upload

### DIFF
--- a/backend/controllers/courseController.js
+++ b/backend/controllers/courseController.js
@@ -5,7 +5,7 @@ const UserCourseAccess = require('../models/UserCourseAccess');
 // Create a new course
 exports.createCourse = async (req, res) => {
   try {
-    const { title, description, price, durationInDays, type, grade, subject, teacherName } = req.body;
+    const { title, description, price, durationInDays, type, grade, subject, teacherName, imageUrl } = req.body;
 
     if (!title || !price) {
       return res.status(400).json({ message: 'Title and price are required' });
@@ -20,6 +20,7 @@ exports.createCourse = async (req, res) => {
       grade,
       subject,
       teacherName,
+      imageUrl,
       createdBy: req.user?.userId || null
     });
 
@@ -120,7 +121,7 @@ exports.getCourseById = async (req, res) => {
 exports.updateCourse = async (req, res) => {
   try {
     const { id } = req.params;
-    const { title, description, price, durationInDays, type, grade, subject, teacherName } = req.body;
+    const { title, description, price, durationInDays, type, grade, subject, teacherName, imageUrl } = req.body;
 
     const course = await Course.findByIdAndUpdate(
       id,
@@ -132,7 +133,8 @@ exports.updateCourse = async (req, res) => {
         type: type || 'class',
         grade,
         subject,
-        teacherName
+        teacherName,
+        imageUrl
       },
       { new: true, runValidators: true }
     );
@@ -159,6 +161,7 @@ exports.updateFullCourse = async (req, res) => {
       grade,
       subject,
       teacherName,
+      imageUrl,
       courseContent
     } = req.body;
 
@@ -173,6 +176,7 @@ exports.updateFullCourse = async (req, res) => {
     if (grade !== undefined) course.grade = grade;
     if (subject !== undefined) course.subject = subject;
     if (teacherName !== undefined) course.teacherName = teacherName;
+    if (imageUrl !== undefined) course.imageUrl = imageUrl;
 
     if (Array.isArray(courseContent)) {
       course.courseContent = courseContent.map((c) => ({

--- a/backend/models/Course.js
+++ b/backend/models/Course.js
@@ -4,6 +4,7 @@ const courseSchema = new mongoose.Schema({
   grade: { type: String },
   subject: { type: String },
   teacherName: { type: String },
+  imageUrl: String,
 
   title: {
     type: String,

--- a/frontend/src/pages/Admin/CreateCourse.jsx
+++ b/frontend/src/pages/Admin/CreateCourse.jsx
@@ -1,10 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../../api';
 
 function CreateCourse() {
+  const [step, setStep] = useState('info');
+  const [courseId, setCourseId] = useState(null);
   const [form, setForm] = useState({
     title: '',
+    imageUrl: '',
     description: '',
     price: '',
     durationInDays: 30,
@@ -15,6 +18,9 @@ function CreateCourse() {
   const [teachers, setTeachers] = useState([]);
   const [subjects, setSubjects] = useState([]);
   const [message, setMessage] = useState('');
+  const [content, setContent] = useState([
+    { title: '', videoUrl: '', isPublic: false }
+  ]);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -25,7 +31,7 @@ function CreateCourse() {
     }
     api
       .get(`/teachers/available-subjects?grade=${form.grade}`)
-      .then((res) => setSubjects(res.data.subjects || []))
+      .then(res => setSubjects(res.data.subjects || []))
       .catch(() => setSubjects([]));
   }, [form.grade]);
 
@@ -36,7 +42,7 @@ function CreateCourse() {
     }
     api
       .get(`/teachers?grade=${form.grade}&subject=${encodeURIComponent(form.subject)}`)
-      .then((res) => setTeachers(res.data.teachers || []))
+      .then(res => setTeachers(res.data.teachers || []))
       .catch(() => setTeachers([]));
   }, [form.grade, form.subject]);
 
@@ -51,14 +57,45 @@ function CreateCourse() {
     }
   };
 
-  const handleSubmit = async (e) => {
+  const submitInfo = async (e) => {
     e.preventDefault();
     try {
       const res = await api.post('/courses', form);
-      setMessage('Course created!');
-      navigate(`/admin/courses/${res.data.course._id}/upload`);
+      setCourseId(res.data.course._id);
+      setStep('content');
+      setMessage('Course created. Now add content');
     } catch (err) {
-      setMessage('Creation failed.');
+      setMessage('Creation failed');
+    }
+  };
+
+  const handleContentChange = (idx, field, value) => {
+    const updated = [...content];
+    updated[idx][field] = value;
+    setContent(updated);
+  };
+
+  const addContent = () => {
+    setContent([...content, { title: '', videoUrl: '', isPublic: false }]);
+  };
+
+  const removeContent = (idx) => {
+    const updated = content.filter((_, i) => i !== idx);
+    setContent(updated.length ? updated : [{ title: '', videoUrl: '', isPublic: false }]);
+  };
+
+  const submitContent = async (e) => {
+    e.preventDefault();
+    if (!courseId) return;
+    try {
+      await Promise.all(content.map(item => api.post(`/courses/${courseId}/content`, {
+        title: item.title,
+        videoUrl: item.videoUrl,
+        isPublic: item.isPublic
+      })));
+      navigate('/admin/courses');
+    } catch {
+      setMessage('Failed to save content');
     }
   };
 
@@ -66,79 +103,126 @@ function CreateCourse() {
     <div className="container mt-4">
       <h2>Create Course</h2>
       {message && <div className="alert alert-info">{message}</div>}
-      <form onSubmit={handleSubmit}>
-        <input
-          className="form-control mb-2"
-          name="title"
-          placeholder="Title"
-          value={form.title}
-          onChange={handleChange}
-          required
-        />
-        <textarea
-          className="form-control mb-2"
-          name="description"
-          placeholder="Description"
-          value={form.description}
-          onChange={handleChange}
-        />
-        <input
-          className="form-control mb-2"
-          name="price"
-          type="number"
-          placeholder="Price"
-          value={form.price}
-          onChange={handleChange}
-          required
-        />
-        <input
-          className="form-control mb-2"
-          name="durationInDays"
-          type="number"
-          placeholder="Duration in days"
-          value={form.durationInDays}
-          onChange={handleChange}
-        />
-        <select
-          className="form-control mb-2"
-          name="grade"
-          value={form.grade}
-          onChange={handleChange}
-          required
-        >
-          <option value="">Select Grade</option>
-          {[...Array(13)].map((_, i) => (
-            <option key={i + 1} value={i + 1}>Grade {i + 1}</option>
+      {step === 'info' && (
+        <form onSubmit={submitInfo}>
+          <input
+            className="form-control mb-2"
+            name="title"
+            placeholder="Title"
+            value={form.title}
+            onChange={handleChange}
+            required
+          />
+          <input
+            className="form-control mb-2"
+            name="imageUrl"
+            placeholder="Image URL"
+            value={form.imageUrl}
+            onChange={handleChange}
+          />
+          <textarea
+            className="form-control mb-2"
+            name="description"
+            placeholder="Description"
+            value={form.description}
+            onChange={handleChange}
+          />
+          <input
+            className="form-control mb-2"
+            name="price"
+            type="number"
+            placeholder="Price"
+            value={form.price}
+            onChange={handleChange}
+            required
+          />
+          <input
+            className="form-control mb-2"
+            name="durationInDays"
+            type="number"
+            placeholder="Duration in days"
+            value={form.durationInDays}
+            onChange={handleChange}
+          />
+          <select
+            className="form-control mb-2"
+            name="grade"
+            value={form.grade}
+            onChange={handleChange}
+            required
+          >
+            <option value="">Select Grade</option>
+            {[...Array(13)].map((_, i) => (
+              <option key={i + 1} value={i + 1}>Grade {i + 1}</option>
+            ))}
+          </select>
+          <select
+            className="form-control mb-2"
+            name="subject"
+            value={form.subject}
+            onChange={handleChange}
+            required
+          >
+            <option value="">Select Subject</option>
+            {subjects.map(s => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <select
+            className="form-control mb-2"
+            name="teacherName"
+            value={form.teacherName}
+            onChange={handleChange}
+            required
+          >
+            <option value="">Select Teacher</option>
+            {teachers.map(t => (
+              <option key={t._id} value={`${t.firstName} ${t.lastName}`}>{t.firstName} {t.lastName}</option>
+            ))}
+          </select>
+          <button className="btn btn-primary">Create &amp; Next</button>
+        </form>
+      )}
+
+      {step === 'content' && (
+        <form onSubmit={submitContent}>
+          {content.map((c, idx) => (
+            <div key={idx} className="border rounded p-3 mb-3">
+              <input
+                type="text"
+                className="form-control mb-2"
+                placeholder="Content Title"
+                value={c.title}
+                onChange={e => handleContentChange(idx, 'title', e.target.value)}
+                required
+              />
+              <input
+                type="text"
+                className="form-control mb-2"
+                placeholder="Video URL"
+                value={c.videoUrl}
+                onChange={e => handleContentChange(idx, 'videoUrl', e.target.value)}
+                required
+              />
+              <select
+                className="form-control mb-2"
+                value={c.isPublic ? 'unpaid' : 'paid'}
+                onChange={e => handleContentChange(idx, 'isPublic', e.target.value === 'unpaid')}
+              >
+                <option value="paid">Paid Students</option>
+                <option value="unpaid">Unpaid Students</option>
+              </select>
+              {content.length > 1 && (
+                <button type="button" className="btn btn-sm btn-danger" onClick={() => removeContent(idx)}>Remove</button>
+              )}
+            </div>
           ))}
-        </select>
-        <select
-          className="form-control mb-2"
-          name="subject"
-          value={form.subject}
-          onChange={handleChange}
-          required
-        >
-          <option value="">Select Subject</option>
-          {subjects.map((s) => (
-            <option key={s} value={s}>{s}</option>
-          ))}
-        </select>
-        <select
-          className="form-control mb-2"
-          name="teacherName"
-          value={form.teacherName}
-          onChange={handleChange}
-          required
-        >
-          <option value="">Select Teacher</option>
-          {teachers.map((t) => (
-            <option key={t._id} value={`${t.firstName} ${t.lastName}`}>
-              {t.firstName} {t.lastName}
-            </option>
-          ))}
-        </select>
-        <button className="btn btn-primary">Create</button>
-      </form>
+          <button type="button" className="btn btn-secondary mb-3" onClick={addContent}>➕ Add Content</button>
+          <div>
+            <button type="submit" className="btn btn-success">Save</button>
+          </div>
+        </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- support `imageUrl` for courses
- include `imageUrl` in course controller CRUD routes
- redesign admin course creation page with a two-step flow
  - add course info first (title, image url, description, price, grade, subject, teacher)
  - then add multiple content entries with paid/unpaid access control

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6861f1621c508322bc71f894a18c7660