### PR TITLE
Add Vercel deployment configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,20 @@ A 401 response usually means the Bunny API rejected the credentials. Double-chec
 6. Ensure no extra whitespace or newline characters are present in your `.env` values.
 
 
+## Deploying to Vercel
+
+Both the backend and frontend can be deployed as separate projects on Vercel. The repository already contains configuration files for each part.
+
+### Backend
+
+1. Inside the `backend` directory run `vercel` and create a new project.
+2. Vercel will detect the `vercel.json` file which builds `api/index.js` as a serverless function.
+3. Copy the variables from `backend/.env.example` into the project settings on Vercel. Use the same names so the Express app can access them.
+
+### Frontend
+
+1. In the `frontend` directory run `vercel` and create another project.
+2. Set the `VITE_API_BASE_URL` environment variable to the URL of the deployed backend followed by `/api`.
+3. Vercel uses `frontend/vercel.json` to build the Vite project and serve the compiled assets.
+
+After both deployments complete, the frontend will call the backend using the URL defined in `VITE_API_BASE_URL`.

--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -1,0 +1,4 @@
+const serverless = require('serverless-http');
+const app = require('../app');
+
+module.exports = serverless(app);

--- a/backend/app.js
+++ b/backend/app.js
@@ -54,16 +54,20 @@ mongoose.connect(process.env.MONGO_URI)
   .then(() => console.log('✅ MongoDB connected'))
   .catch(err => console.error('❌ MongoDB connection error:', err));
 
-const PORT = process.env.PORT || 5000;
-app.listen(PORT, () => {
-  console.log(`🚀 Server running on port ${PORT}`);
-  console.log(`📁 Environment: ${process.env.NODE_ENV || 'development'}`);
-  
-  // Log environment variables status (without exposing values)
-  console.log('🔧 Environment check:');
-  console.log(`   MONGO_URI: ${process.env.MONGO_URI ? '✅ Set' : '❌ Missing'}`);
-  console.log(`   JWT_SECRET: ${process.env.JWT_SECRET ? '✅ Set' : '❌ Missing'}`);
-  console.log(`   BUNNY_API_KEY: ${process.env.BUNNY_API_KEY ? '✅ Set' : '❌ Missing'}`);
-  console.log(`   BUNNY_LIBRARY_ID: ${process.env.BUNNY_LIBRARY_ID ? '✅ Set' : '❌ Missing'}`);
-  console.log(`   PAYHERE_MERCHANT_ID: ${process.env.PAYHERE_MERCHANT_ID ? '✅ Set' : '❌ Missing'}`);
-});
+if (require.main === module) {
+  const PORT = process.env.PORT || 5000;
+  app.listen(PORT, () => {
+    console.log(`🚀 Server running on port ${PORT}`);
+    console.log(`📁 Environment: ${process.env.NODE_ENV || 'development'}`);
+
+    // Log environment variables status (without exposing values)
+    console.log('🔧 Environment check:');
+    console.log(`   MONGO_URI: ${process.env.MONGO_URI ? '✅ Set' : '❌ Missing'}`);
+    console.log(`   JWT_SECRET: ${process.env.JWT_SECRET ? '✅ Set' : '❌ Missing'}`);
+    console.log(`   BUNNY_API_KEY: ${process.env.BUNNY_API_KEY ? '✅ Set' : '❌ Missing'}`);
+    console.log(`   BUNNY_LIBRARY_ID: ${process.env.BUNNY_LIBRARY_ID ? '✅ Set' : '❌ Missing'}`);
+    console.log(`   PAYHERE_MERCHANT_ID: ${process.env.PAYHERE_MERCHANT_ID ? '✅ Set' : '❌ Missing'}`);
+  });
+}
+
+module.exports = app;

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,8 @@
     "mongoose": "^8.15.0",
     "nodemailer": "^7.0.3",
     "nodemon": "^3.1.10",
-    "twilio": "^5.6.1"
+    "twilio": "^5.6.1",
+    "serverless-http": "^3.2.0"
   },
   "devDependencies": {
     "concurrently": "^9.1.2",

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/index.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "api/index.js" }
+  ]
+}

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://localhost:5000/api',
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api',
 });
 
 api.interceptors.request.use((config) => {

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- export Express app for serverless usage
- add serverless entrypoint and config for backend
- add Vercel configuration for frontend
- allow API base URL via `VITE_API_BASE_URL`
- document separate backend and frontend deployment to Vercel

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686210b8945483228355381140e19dbc