### PR TITLE
Fix uploads on Vercel

### DIFF
--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -2,10 +2,12 @@ const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
 
-// Directory where temporary uploads will be stored before
-// being sent to Bunny.net. Multer does not create this
-// automatically, so ensure it exists.
-const uploadDir = path.join(__dirname, '..', 'uploads');
+// Directory where temporary uploads will be stored before being sent to
+// Bunny.net. In serverless environments like Vercel the application files
+// are read-only, so we fall back to the system temp directory which is
+// writable. Allow overriding via the UPLOAD_DIR environment variable.
+const defaultDir = path.join(__dirname, '..', 'uploads');
+const uploadDir = process.env.UPLOAD_DIR || (process.env.VERCEL ? '/tmp/uploads' : defaultDir);
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir, { recursive: true });
 }

--- a/backend/middleware/uploadSubtitle.js
+++ b/backend/middleware/uploadSubtitle.js
@@ -2,7 +2,13 @@ const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
 
-const uploadDir = path.join(__dirname, '..', 'uploads', 'subtitles');
+// Directory for subtitle uploads. Serverless environments use a read-only
+// filesystem for the application code, so default to the system temp directory
+// when running on Vercel. This can also be overridden with UPLOAD_DIR.
+const defaultDir = path.join(__dirname, '..', 'uploads', 'subtitles');
+const uploadDir = process.env.UPLOAD_DIR
+  ? path.join(process.env.UPLOAD_DIR, 'subtitles')
+  : (process.env.VERCEL ? '/tmp/uploads/subtitles' : defaultDir);
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir, { recursive: true });
 }


### PR DESCRIPTION
## Summary
- ensure upload middleware uses tmp dir on Vercel
- support subtitle uploads on serverless
- serve uploads from tmp in production

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621a48c2888322b625fe531cb9cb61