### PR TITLE
Configure frontend API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,11 @@ Both the backend and frontend can be deployed as separate projects on Vercel. Th
 ### Frontend
 
 1. In the `frontend` directory run `vercel` and create another project.
-2. Set the `VITE_API_BASE_URL` environment variable to the URL of the deployed backend followed by `/api`.
+2. Set the `VITE_API_BASE_URL` environment variable to the URL of the deployed backend followed by `/api`. For example:
+
+```bash
+VITE_API_BASE_URL=https://lmc-server.vercel.app/api
+```
 3. Vercel uses `frontend/vercel.json` to build the Vite project and serve the compiled assets.
 
 After both deployments complete, the frontend will call the backend using the URL defined in `VITE_API_BASE_URL`.

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://lmc-server.vercel.app/api


### PR DESCRIPTION
## Summary
- set frontend API base URL for the deployed backend
- document example configuration in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find ESLint deps)*

------
https://chatgpt.com/codex/tasks/task_e_68621ce561108322873f5c8ef0e0b384