### PR TITLE
Fix Vercel timeout

### DIFF
--- a/backend/api/index.js
+++ b/backend/api/index.js
@@ -3,4 +3,11 @@ const serverless = require('serverless-http');
 // `app.js`, but it now lives at `index.js`.
 const app = require('../index');
 
-module.exports = serverless(app);
+// In a serverless environment, open handles like database connections or the
+// express-session store can keep the event loop active which prevents the
+// request from finishing. By explicitly disabling the wait for the empty event
+// loop, we ensure the response is returned immediately once Express finishes
+// processing.
+module.exports = serverless(app, {
+  callbackWaitsForEmptyEventLoop: false
+});


### PR DESCRIPTION
## Summary
- prevent the backend serverless function from waiting for the empty event loop
  so the response returns as soon as Express finishes processing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686220f56778832296d342638fe93aaf