### PR TITLE
Add default and 404 routes

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -56,6 +56,16 @@ app.use('/api/teachers', teacherRoutes);
 app.use('/api/notices', noticeRoutes);
 app.use('/api', productRoutes);
 
+// Basic health check route for root path
+app.get('/', (req, res) => {
+  res.send('Backend is running');
+});
+
+// Catch-all for unmatched routes to prevent hanging requests
+app.use((req, res) => {
+  res.status(404).json({ message: 'Route not found' });
+});
+
 // Connect to MongoDB (removed deprecated options)
 mongoose.connect(process.env.MONGO_URI)
   .then(() => console.log('✅ MongoDB connected'))


### PR DESCRIPTION
## Summary
- handle requests to `/` with a healthcheck message
- add catch‑all route to respond with 404 instead of timing out

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862239fd6cc83228960198737d96a66