### PR TITLE
Fix MongoDB connection timeout

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -66,8 +66,13 @@ app.use((req, res) => {
   res.status(404).json({ message: 'Route not found' });
 });
 
-// Connect to MongoDB (removed deprecated options)
-mongoose.connect(process.env.MONGO_URI)
+// Connect to MongoDB with a short server selection timeout so a missing or
+// unreachable database doesn't cause the Vercel function to hang for the full
+// 300 second Lambda timeout. This fails fast and surfaces the error to the
+// caller instead of returning a 504 gateway timeout.
+mongoose.connect(process.env.MONGO_URI, {
+  serverSelectionTimeoutMS: 5000
+})
   .then(() => console.log(' MongoDB connected'))
   .catch(err => console.error(' MongoDB connection error:', err));
 


### PR DESCRIPTION
## Summary
- set a short `serverSelectionTimeoutMS` for Mongoose so the backend fails fast when the database is unreachable

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686227c504848322a29cd22979373a85