### PR TITLE
Fix routing for Vercel

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -4,6 +4,7 @@
     { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
   ],
   "routes": [
+    { "handle": "filesystem" },
     { "src": "/(.*)", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- serve static assets before rewriting to `index.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686232822a408322912199843b75f276