### PR TITLE
Fix DB connection timeout on Vercel

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,16 +1,38 @@
 const mongoose = require('mongoose');
 
+/**
+ * Cached connection across Vercel serverless invocations.
+ * Without caching a new connection is created for every request which can
+ * quickly exhaust the database connection limit and appear as a timeout.
+ */
+let cached = global.mongoose;
+
+if (!cached) {
+  cached = global.mongoose = { conn: null, promise: null };
+}
+
 const connectDB = async () => {
-  try {
-    await mongoose.connect(process.env.MONGO_URI, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-    });
-    console.log('MongoDB Connected');
-  } catch (error) {
-    console.error('MongoDB Connection Error:', error.message);
-    process.exit(1);
+  if (cached.conn) return cached.conn;
+
+  if (!cached.promise) {
+    cached.promise = mongoose
+      .connect(process.env.MONGO_URI, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+      })
+      .then((mongoose) => {
+        console.log('MongoDB Connected');
+        return mongoose;
+      })
+      .catch((error) => {
+        cached.promise = null;
+        console.error('MongoDB Connection Error:', error.message);
+        throw error;
+      });
   }
+
+  cached.conn = await cached.promise;
+  return cached.conn;
 };
 
 module.exports = connectDB;

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 require('dotenv').config({ path: path.join(__dirname, '.env') });
 const express = require('express');
-const mongoose = require('mongoose');
+const connectDB = require('./config/db');
 const cors = require('cors');
 const bodyParser = require('body-parser');
 const session = require('express-session');
@@ -56,10 +56,9 @@ app.use('/api/teachers', teacherRoutes);
 app.use('/api/notices', noticeRoutes);
 app.use('/api', productRoutes);
 
-// Connect to MongoDB (removed deprecated options)
-mongoose.connect(process.env.MONGO_URI)
-  .then(() => console.log(' MongoDB connected'))
-  .catch(err => console.error(' MongoDB connection error:', err));
+// Connect to MongoDB. When deployed to Vercel the same instance may handle
+// multiple requests, so reuse the cached connection from ./config/db.js.
+connectDB().catch(err => console.error(' MongoDB connection error:', err));
 
 if (require.main === module) {
   const PORT = process.env.PORT || 5000;


### PR DESCRIPTION
## Summary
- cache MongoDB connection for serverless invocations
- use the cached connection in the Express app

## Testing
- `npm test` (fails: jest not found)
- `npm test` in `frontend` (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_68623c795fd88322a6bad81eb6df2f41