### PR TITLE
Fix PayHere base URL on Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Both the backend and frontend can be deployed as separate projects on Vercel. Th
 1. Inside the `backend` directory run `vercel` and create a new project.
 2. Vercel will detect the `vercel.json` file which builds `index.js` as a serverless function.
 3. Copy the variables from `backend/.env.example` into the project settings on Vercel. Use the same names so the Express app can access them.
+4. Set `BASE_URL` to the full HTTPS URL of the deployed backend. If omitted, the server will try to detect the value from the `VERCEL_URL` environment variable.
+   Make sure this URL is also registered in your PayHere account or payments will be rejected as **Unauthorized**.
 
 ### Frontend
 

--- a/backend/controllers/paymentController.js
+++ b/backend/controllers/paymentController.js
@@ -79,7 +79,9 @@ exports.initiatePayment = async (req, res) => {
 
     await payment.save();
 
-    const baseUrl = process.env.BASE_URL || 'http://localhost:5000';
+    const baseUrl =
+      process.env.BASE_URL ||
+      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:5000');
 
     const paymentData = {
       sandbox: process.env.PAYHERE_SANDBOX === 'true',

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -99,7 +99,9 @@ exports.initiateCheckout = async (req, res) => {
     const amount = total.toFixed(2);
     const hash = generatePayHereHash(merchantId, orderId, amount, currency, merchantSecret);
 
-    const baseUrl = process.env.BASE_URL || 'http://localhost:5000';
+    const baseUrl =
+      process.env.BASE_URL ||
+      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:5000');
 
     const paymentData = {
       sandbox: process.env.PAYHERE_SANDBOX === 'true',


### PR DESCRIPTION
## Summary
- detect `VERCEL_URL` when building PayHere URLs so deployments work without a custom `BASE_URL`
- document how to set `BASE_URL` and register the domain with PayHere

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624146b8688322886fcaf3b5f08787