### PR TITLE
Fix admin content access labels

### DIFF
--- a/frontend/src/pages/Admin/CourseUploader.jsx
+++ b/frontend/src/pages/Admin/CourseUploader.jsx
@@ -742,7 +742,7 @@ function CourseUploader() {
                           checked={item.paidAccess}
                           onChange={(e) => updateContentItem(item.id, 'paidAccess', e.target.checked)}
                         />
-                        <label htmlFor={`paid-${item.id}`}>Access paid Student</label>
+                        <label htmlFor={`paid-${item.id}`}>Restrict to paid students</label>
                       </div>
                       <div className="access-option">
                         <input 
@@ -752,7 +752,7 @@ function CourseUploader() {
                           checked={item.unpaidAccess}
                           onChange={(e) => updateContentItem(item.id, 'unpaidAccess', e.target.checked)}
                         />
-                        <label htmlFor={`unpaid-${item.id}`}>Access unpaid all Student</label>
+                        <label htmlFor={`unpaid-${item.id}`}>Allow access for unpaid students</label>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- update content access labels in `CourseUploader`

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626a736ab883229b6f4c4a7432dfcd