### PR TITLE
Fix database timeout on Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ Both the backend and frontend can be deployed as separate projects on Vercel. Th
 1. Inside the `backend` directory run `vercel` and create a new project.
 2. Vercel will detect the `vercel.json` file which builds `index.js` as a serverless function.
 3. Copy the variables from `backend/.env.example` into the project settings on Vercel. Use the same names so the Express app can access them.
-4. Ensure your MongoDB cluster allows connections from Vercel. If you use MongoDB Atlas, add `0.0.0.0/0` or the specific Vercel IPs to your access list, otherwise database connections may fail after a cold start.
-5. Set `BASE_URL` to the full HTTPS URL of the deployed backend. If omitted, the server will try to detect the value from the `VERCEL_URL` environment variable.
+4. A database connection middleware now ensures MongoDB is available before handling each request. If you experienced `Operation buffering timed out after 10000ms` errors on Vercel, redeploy with this update.
+5. Ensure your MongoDB cluster allows connections from Vercel. If you use MongoDB Atlas, add `0.0.0.0/0` or the specific Vercel IPs to your access list, otherwise database connections may fail after a cold start.
+6. Set `BASE_URL` to the full HTTPS URL of the deployed backend. If omitted, the server will try to detect the value from the `VERCEL_URL` environment variable.
    Make sure this URL is also registered in your PayHere account or payments will be rejected as **Unauthorized**.
 
 ### Frontend

--- a/backend/index.js
+++ b/backend/index.js
@@ -7,6 +7,7 @@ const connectDB = require('./config/db');
 const cors = require('cors');
 const bodyParser = require('body-parser');
 const session = require('express-session');
+const ensureDb = require('./middleware/dbConnect');
 
 // Import Routes
 const authRoutes = require('./routes/authRoutes');
@@ -23,6 +24,7 @@ const app = express();
 
 app.use(cors());
 app.use(bodyParser.json());
+app.use(ensureDb);
 
 // Serve uploaded files. When running in a serverless environment such as Vercel
 // the application directory is read-only, so store temporary uploads in /tmp.
@@ -56,9 +58,7 @@ app.use('/api/teachers', teacherRoutes);
 app.use('/api/notices', noticeRoutes);
 app.use('/api', productRoutes);
 
-// Connect to MongoDB. When deployed to Vercel the same instance may handle
-// multiple requests, so reuse the cached connection from ./config/db.js.
-connectDB().catch(err => console.error(' MongoDB connection error:', err));
+// Database connection handled via middleware for each request
 
 if (require.main === module) {
   const PORT = process.env.PORT || 5000;

--- a/backend/middleware/dbConnect.js
+++ b/backend/middleware/dbConnect.js
@@ -1,0 +1,11 @@
+const connectDB = require('../config/db');
+
+module.exports = async (req, res, next) => {
+  try {
+    await connectDB();
+    next();
+  } catch (err) {
+    console.error('MongoDB connection error:', err);
+    next(err);
+  }
+};


### PR DESCRIPTION
## Summary
- handle DB connection per request via new middleware
- use the middleware in the Express app
- document the fix in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ef069c10832289da96c4c99d4789